### PR TITLE
Discrete priors

### DIFF
--- a/R/sampler.R
+++ b/R/sampler.R
@@ -303,7 +303,8 @@ setMethod("get_marginal_latent_type_prob", "SamplingResults", function(r, no_sim
     full_join(filter(r@sampler@endogenous_latent_type_variables, !discretized), ., by = "marginal_latent_type_index") %>%
     mutate(estimand_quantiles = map(iter_data, quantilize_est, iter_p_r, wide = TRUE, quant_probs = quants),
            mean = map_dbl(iter_data, ~ mean(.$iter_p_r))) %>%
-    unnest(estimand_quantiles)
+    unnest(estimand_quantiles) %>%
+    relocate(iter_data, .after = last_col())
 
   discretized_marginal_prob <- if (has_discretized_variables(r@sampler@structural_model)) {
     discrete_type_variables <- r@sampler@endogenous_latent_type_variables %>%

--- a/R/sampler.R
+++ b/R/sampler.R
@@ -91,7 +91,9 @@ setMethod("sampling", "Sampler", function(object, ...,
 #'
 #' @importMethodsFrom rstan vb
 #' @export
-setMethod("vb", "Sampler", function(object, ..., run_type = c("fit", "prior-predict"), save_background_joint_prob = FALSE) {
+setMethod("vb", "Sampler", function(object, ...,
+                                    pars = c("iter_estimand", "iter_level_entity_estimand", "iter_level_entity_estimand_sd", "log_lik", "iter_between_level_entity_diff_estimand"),
+                                    run_type = c("fit", "prior-predict"), save_background_joint_prob = FALSE) {
   run_type <- arg_match(run_type) %>%
     factor(levels = c("prior-predict", "fit"))
 
@@ -101,10 +103,12 @@ setMethod("vb", "Sampler", function(object, ..., run_type = c("fit", "prior-pred
      stop("Sample data cannot be specified. Data is prepared in the sampler constructor.")
   }
 
-  pars <- c("iter_estimand", "iter_level_entity_estimand", "log_lik")
+  if (object@stan_data$calculate_marginal_prob) {
+    pars %<>% c("single_discrete_marginal_p_r", "discretized_marginal_p_r", "discrete_marginal_p_r")
+  }
 
   if (save_background_joint_prob) {
-    pars %<>%  c("r_log_prob")
+    pars %<>% c("r_log_prob")
   }
 
   args <- lst(

--- a/inst/stan/bounded.stan
+++ b/inst/stan/bounded.stan
@@ -243,6 +243,7 @@ data {
 
   // Priors
 
+  vector[num_discrete_r_types] discrete_beta_hyper_mean;
   matrix[num_discretized_r_types, num_discrete_r_types] discretized_beta_hyper_mean;
 
   real<lower = 0> discrete_beta_hyper_sd;
@@ -862,7 +863,7 @@ transformed parameters {
 }
 
 model {
-  toplevel_discrete_beta ~ normal(0, discrete_beta_hyper_sd);
+  toplevel_discrete_beta ~ normal(discrete_beta_hyper_mean, discrete_beta_hyper_sd);
 
   if (num_levels > 0) {
     to_vector(discrete_level_beta_raw) ~ std_normal();

--- a/inst/stan/bounded.stan
+++ b/inst/stan/bounded.stan
@@ -770,10 +770,8 @@ parameters {
   matrix[num_discrete_r_types, sum(level_size)] discrete_level_beta_raw;
   matrix<lower = 0>[num_discrete_r_types, num_levels] discrete_level_beta_sigma;
 
-  // matrix[num_discretized_r_types, num_discrete_r_types] toplevel_discretized_beta[num_discretized_variables];
   vector[sum(num_discretized_types_conditional)] toplevel_discretized_beta[num_discretized_variables];
 
-  // matrix[num_discretized_r_types * num_discrete_r_types, sum(level_size)] discretized_level_beta_raw[num_discretized_variables];
   matrix[sum(num_discretized_types_conditional), sum(level_size)] discretized_level_beta_raw[num_discretized_variables];
   matrix<lower = 0>[num_discretized_r_types, num_levels] discretized_level_beta_sigma[num_discretized_variables];
 }
@@ -785,25 +783,9 @@ transformed parameters {
 
   matrix[num_discrete_r_types, num_unique_entities] discrete_beta = rep_matrix(toplevel_discrete_beta, num_unique_entities);
 
-  // matrix[num_discretized_r_types * num_discrete_r_types, num_unique_entities] discretized_beta[num_discretized_variables];
   matrix[sum(num_discretized_types_conditional), num_unique_entities] discretized_beta[num_discretized_variables];
 
   for (discretized_var_index in 1:num_discretized_variables) {
-    // matrix[num_discretized_r_types, num_discrete_r_types] curr_discretized_beta = rep_matrix(0, num_discretized_r_types, num_discrete_r_types);
-    // vector[sum(num_discretized_types_conditional)] curr_discretized_beta = toplevel_discretized_beta[discretized_var_index];
-
-    // int discretized_beta_pos = 1;
-    //
-    // for (discrete_type_index in 1:num_discrete_r_types) {
-    //   int discretized_beta_end = discretized_beta_pos + num_discretized_types_conditional[discrete_type_index] - 1;
-    //
-    //   curr_discretized_beta[discretized_types_conditional[discretized_beta_pos:discretized_beta_end], discrete_type_index] =
-    //     toplevel_discretized_beta[discretized_var_index, discretized_types_conditional[discretized_beta_pos:discretized_beta_end]];
-    //
-    //   discretized_beta_pos = discretized_beta_end + 1;
-    // }
-
-    // discretized_beta[discretized_var_index] = rep_matrix(to_vector(curr_discretized_beta), num_unique_entities);
     discretized_beta[discretized_var_index] = rep_matrix(toplevel_discretized_beta[discretized_var_index], num_unique_entities);
   }
 
@@ -821,11 +803,7 @@ transformed parameters {
       for (discretized_var_index in 1:num_discretized_variables) {
         matrix[sum(num_discretized_types_conditional), level_size[level_index]] curr_discretized_level_beta =
           discretized_level_beta_raw[discretized_var_index, , level_entity_pos:level_entity_end] .*
-          // rep_matrix(to_vector(rep_matrix(discretized_level_beta_sigma[discretized_var_index, , level_index], num_discrete_r_types)), level_size[level_index]);
           rep_matrix(discretized_level_beta_sigma[discretized_var_index, discretized_types_conditional , level_index], level_size[level_index]);
-
-        // print("discretized_beta[discretized_var_index] = ", discretized_beta[discretized_var_index]);
-        // print("curr_discretized_level_beta[, unique_entity_ids[, level_index]] = ", curr_discretized_level_beta[, unique_entity_ids[, level_index]]);
 
         discretized_beta[discretized_var_index] += curr_discretized_level_beta[, unique_entity_ids[, level_index]];
       }
@@ -874,8 +852,6 @@ model {
   }
 
   for (discretized_var_index in 1:num_discretized_variables) {
-    // to_vector(toplevel_discretized_beta[discretized_var_index]) ~ normal(to_vector(discretized_beta_hyper_mean), to_vector(discretized_beta_hyper_sd));
-
     int discretized_beta_pos = 1;
 
     for (discrete_type_index in 1:num_discrete_r_types) {

--- a/src/stanExports_bounded.h
+++ b/src/stanExports_bounded.h
@@ -45,7 +45,7 @@ stan::io::program_reader prog_reader__() {
     reader.add_event(333, 0, "start", "include/r_type_prob.stan");
     reader.add_event(427, 94, "end", "include/r_type_prob.stan");
     reader.add_event(427, 4, "restart", "model_bounded");
-    reader.add_event(1567, 1142, "end", "model_bounded");
+    reader.add_event(1568, 1143, "end", "model_bounded");
     return reader;
 }
 int
@@ -2018,6 +2018,7 @@ private:
         int num_discrete_utility_values;
         vector_d utility;
         int log_lik_level;
+        vector_d discrete_beta_hyper_mean;
         matrix_d discretized_beta_hyper_mean;
         double discrete_beta_hyper_sd;
         matrix_d discretized_beta_hyper_sd;
@@ -2784,6 +2785,16 @@ public:
             check_greater_or_equal(function__, "log_lik_level", log_lik_level, -(1));
             check_less_or_equal(function__, "log_lik_level", log_lik_level, num_levels);
             current_statement_begin__ = 669;
+            validate_non_negative_index("discrete_beta_hyper_mean", "num_discrete_r_types", num_discrete_r_types);
+            context__.validate_dims("data initialization", "discrete_beta_hyper_mean", "vector_d", context__.to_vec(num_discrete_r_types));
+            discrete_beta_hyper_mean = Eigen::Matrix<double, Eigen::Dynamic, 1>(num_discrete_r_types);
+            vals_r__ = context__.vals_r("discrete_beta_hyper_mean");
+            pos__ = 0;
+            size_t discrete_beta_hyper_mean_j_1_max__ = num_discrete_r_types;
+            for (size_t j_1__ = 0; j_1__ < discrete_beta_hyper_mean_j_1_max__; ++j_1__) {
+                discrete_beta_hyper_mean(j_1__) = vals_r__[pos__++];
+            }
+            current_statement_begin__ = 670;
             validate_non_negative_index("discretized_beta_hyper_mean", "num_discretized_r_types", num_discretized_r_types);
             validate_non_negative_index("discretized_beta_hyper_mean", "num_discrete_r_types", num_discrete_r_types);
             context__.validate_dims("data initialization", "discretized_beta_hyper_mean", "matrix_d", context__.to_vec(num_discretized_r_types,num_discrete_r_types));
@@ -2797,14 +2808,14 @@ public:
                     discretized_beta_hyper_mean(j_1__, j_2__) = vals_r__[pos__++];
                 }
             }
-            current_statement_begin__ = 671;
+            current_statement_begin__ = 672;
             context__.validate_dims("data initialization", "discrete_beta_hyper_sd", "double", context__.to_vec());
             discrete_beta_hyper_sd = double(0);
             vals_r__ = context__.vals_r("discrete_beta_hyper_sd");
             pos__ = 0;
             discrete_beta_hyper_sd = vals_r__[pos__++];
             check_greater_or_equal(function__, "discrete_beta_hyper_sd", discrete_beta_hyper_sd, 0);
-            current_statement_begin__ = 672;
+            current_statement_begin__ = 673;
             validate_non_negative_index("discretized_beta_hyper_sd", "num_discretized_r_types", num_discretized_r_types);
             validate_non_negative_index("discretized_beta_hyper_sd", "num_discrete_r_types", num_discrete_r_types);
             context__.validate_dims("data initialization", "discretized_beta_hyper_sd", "matrix_d", context__.to_vec(num_discretized_r_types,num_discrete_r_types));
@@ -2819,7 +2830,7 @@ public:
                 }
             }
             check_greater_or_equal(function__, "discretized_beta_hyper_sd", discretized_beta_hyper_sd, 0);
-            current_statement_begin__ = 674;
+            current_statement_begin__ = 675;
             validate_non_negative_index("tau_level_sigma", "num_levels", num_levels);
             context__.validate_dims("data initialization", "tau_level_sigma", "vector_d", context__.to_vec(num_levels));
             tau_level_sigma = Eigen::Matrix<double, Eigen::Dynamic, 1>(num_levels);
@@ -2830,7 +2841,7 @@ public:
                 tau_level_sigma(j_1__) = vals_r__[pos__++];
             }
             check_greater_or_equal(function__, "tau_level_sigma", tau_level_sigma, 0);
-            current_statement_begin__ = 678;
+            current_statement_begin__ = 679;
             context__.validate_dims("data initialization", "run_type", "int", context__.to_vec());
             run_type = int(0);
             vals_i__ = context__.vals_i("run_type");
@@ -2838,7 +2849,7 @@ public:
             run_type = vals_i__[pos__++];
             check_greater_or_equal(function__, "run_type", run_type, 1);
             check_less_or_equal(function__, "run_type", run_type, 2);
-            current_statement_begin__ = 679;
+            current_statement_begin__ = 680;
             context__.validate_dims("data initialization", "use_random_binpoint", "int", context__.to_vec());
             use_random_binpoint = int(0);
             vals_i__ = context__.vals_i("use_random_binpoint");
@@ -2846,7 +2857,7 @@ public:
             use_random_binpoint = vals_i__[pos__++];
             check_greater_or_equal(function__, "use_random_binpoint", use_random_binpoint, 0);
             check_less_or_equal(function__, "use_random_binpoint", use_random_binpoint, 1);
-            current_statement_begin__ = 680;
+            current_statement_begin__ = 681;
             context__.validate_dims("data initialization", "generate_rep", "int", context__.to_vec());
             generate_rep = int(0);
             vals_i__ = context__.vals_i("generate_rep");
@@ -2854,7 +2865,7 @@ public:
             generate_rep = vals_i__[pos__++];
             check_greater_or_equal(function__, "generate_rep", generate_rep, 0);
             check_less_or_equal(function__, "generate_rep", generate_rep, 1);
-            current_statement_begin__ = 681;
+            current_statement_begin__ = 682;
             context__.validate_dims("data initialization", "calculate_marginal_prob", "int", context__.to_vec());
             calculate_marginal_prob = int(0);
             vals_i__ = context__.vals_i("calculate_marginal_prob");
@@ -2863,461 +2874,461 @@ public:
             check_greater_or_equal(function__, "calculate_marginal_prob", calculate_marginal_prob, 0);
             check_less_or_equal(function__, "calculate_marginal_prob", calculate_marginal_prob, 1);
             // initialize transformed data variables
-            current_statement_begin__ = 685;
+            current_statement_begin__ = 686;
             RUN_TYPE_PRIOR_PREDICT = int(0);
             stan::math::fill(RUN_TYPE_PRIOR_PREDICT, std::numeric_limits<int>::min());
             stan::math::assign(RUN_TYPE_PRIOR_PREDICT,1);
-            current_statement_begin__ = 686;
+            current_statement_begin__ = 687;
             RUN_TYPE_FIT = int(0);
             stan::math::fill(RUN_TYPE_FIT, std::numeric_limits<int>::min());
             stan::math::assign(RUN_TYPE_FIT,2);
-            current_statement_begin__ = 688;
+            current_statement_begin__ = 689;
             num_all_estimands = int(0);
             stan::math::fill(num_all_estimands, std::numeric_limits<int>::min());
             stan::math::assign(num_all_estimands,(((num_discrete_estimands + ((1 + logical_gt(num_discrete_utility_values, 0)) * num_discretized_groups)) + num_mean_diff_estimands) + num_utility_diff_estimands));
-            current_statement_begin__ = 690;
+            current_statement_begin__ = 691;
             discrete_group_size = int(0);
             stan::math::fill(discrete_group_size, std::numeric_limits<int>::min());
             stan::math::assign(discrete_group_size,divide(num_r_types, num_discrete_r_types));
-            current_statement_begin__ = 692;
+            current_statement_begin__ = 693;
             num_discretized_variables = int(0);
             stan::math::fill(num_discretized_variables, std::numeric_limits<int>::min());
             stan::math::assign(num_discretized_variables,std::max((num_cutpoints - 2), 0));
-            current_statement_begin__ = 693;
+            current_statement_begin__ = 694;
             total_num_discretized_bg_variable_types = int(0);
             stan::math::fill(total_num_discretized_bg_variable_types, std::numeric_limits<int>::min());
             stan::math::assign(total_num_discretized_bg_variable_types,((num_discretized_bg_variables * num_discretized_r_types) * num_discrete_r_types));
-            current_statement_begin__ = 694;
+            current_statement_begin__ = 695;
             validate_non_negative_index("num_discretized_types_conditional", "num_discrete_r_types", num_discrete_r_types);
             num_discretized_types_conditional = std::vector<int>(num_discrete_r_types, int(0));
             stan::math::fill(num_discretized_types_conditional, std::numeric_limits<int>::min());
             stan::math::assign(num_discretized_types_conditional,num_unrestricted_by_col(discretized_beta_hyper_sd, discretized_beta_hyper_mean, pstream__));
-            current_statement_begin__ = 696;
+            current_statement_begin__ = 697;
             validate_non_negative_index("discretized_types_conditional", "sum(num_discretized_types_conditional)", sum(num_discretized_types_conditional));
             discretized_types_conditional = std::vector<int>(sum(num_discretized_types_conditional), int(0));
             stan::math::fill(discretized_types_conditional, std::numeric_limits<int>::min());
             stan::math::assign(discretized_types_conditional,which_unrestricted_by_col(discretized_beta_hyper_sd, discretized_beta_hyper_mean, num_discretized_types_conditional, pstream__));
-            current_statement_begin__ = 699;
+            current_statement_begin__ = 700;
             validate_non_negative_index("cutpoint_midpoints", "std::max((num_cutpoints - 1), 0)", std::max((num_cutpoints - 1), 0));
             cutpoint_midpoints = Eigen::Matrix<double, Eigen::Dynamic, 1>(std::max((num_cutpoints - 1), 0));
             stan::math::fill(cutpoint_midpoints, DUMMY_VAR__);
-            current_statement_begin__ = 700;
+            current_statement_begin__ = 701;
             validate_non_negative_index("discretized_binwidth", "std::max((num_cutpoints - 1), 0)", std::max((num_cutpoints - 1), 0));
             discretized_binwidth = Eigen::Matrix<double, Eigen::Dynamic, 1>(std::max((num_cutpoints - 1), 0));
             stan::math::fill(discretized_binwidth, DUMMY_VAR__);
-            current_statement_begin__ = 702;
+            current_statement_begin__ = 703;
             validate_non_negative_index("discretize_bin_alpha", "std::max((num_cutpoints - 1), 0)", std::max((num_cutpoints - 1), 0));
             discretize_bin_alpha = std::vector<double>(std::max((num_cutpoints - 1), 0), double(0));
             stan::math::fill(discretize_bin_alpha, DUMMY_VAR__);
-            current_statement_begin__ = 703;
+            current_statement_begin__ = 704;
             validate_non_negative_index("discretize_bin_beta", "std::max((num_cutpoints - 1), 0)", std::max((num_cutpoints - 1), 0));
             discretize_bin_beta = std::vector<double>(std::max((num_cutpoints - 1), 0), double(0));
             stan::math::fill(discretize_bin_beta, DUMMY_VAR__);
-            current_statement_begin__ = 705;
+            current_statement_begin__ = 706;
             validate_non_negative_index("entity_discretize_bin_alpha", "((num_unique_entities * (num_cutpoints - 1)) * num_discretized_groups)", ((num_unique_entities * (num_cutpoints - 1)) * num_discretized_groups));
             entity_discretize_bin_alpha = std::vector<double>(((num_unique_entities * (num_cutpoints - 1)) * num_discretized_groups), double(0));
             stan::math::fill(entity_discretize_bin_alpha, DUMMY_VAR__);
-            current_statement_begin__ = 706;
+            current_statement_begin__ = 707;
             validate_non_negative_index("entity_discretize_bin_beta", "((num_unique_entities * (num_cutpoints - 1)) * num_discretized_groups)", ((num_unique_entities * (num_cutpoints - 1)) * num_discretized_groups));
             entity_discretize_bin_beta = std::vector<double>(((num_unique_entities * (num_cutpoints - 1)) * num_discretized_groups), double(0));
             stan::math::fill(entity_discretize_bin_beta, DUMMY_VAR__);
-            current_statement_begin__ = 708;
+            current_statement_begin__ = 709;
             num_r_types_full = int(0);
             stan::math::fill(num_r_types_full, std::numeric_limits<int>::min());
             stan::math::assign(num_r_types_full,(num_r_types * num_experiment_types));
-            current_statement_begin__ = 709;
+            current_statement_begin__ = 710;
             validate_non_negative_index("experiment_r_type_index", "num_r_types_full", num_r_types_full);
             experiment_r_type_index = std::vector<int>(num_r_types_full, int(0));
             stan::math::fill(experiment_r_type_index, std::numeric_limits<int>::min());
-            current_statement_begin__ = 711;
+            current_statement_begin__ = 712;
             validate_non_negative_index("full_experiment_types_prob", "num_r_types_full", num_r_types_full);
             full_experiment_types_prob = Eigen::Matrix<double, Eigen::Dynamic, 1>(num_r_types_full);
             stan::math::fill(full_experiment_types_prob, DUMMY_VAR__);
             stan::math::assign(full_experiment_types_prob,to_vector(rep_matrix(experiment_types_prob, num_r_types)));
-            current_statement_begin__ = 713;
+            current_statement_begin__ = 714;
             validate_non_negative_index("level_size", "num_levels", num_levels);
             level_size = std::vector<int>(num_levels, int(0));
             stan::math::fill(level_size, std::numeric_limits<int>::min());
             stan::math::assign(level_size,calculate_level_size(num_levels, unique_entity_ids, pstream__));
-            current_statement_begin__ = 714;
+            current_statement_begin__ = 715;
             validate_non_negative_index("num_obs_in_unique_entity", "num_unique_entities", num_unique_entities);
             num_obs_in_unique_entity = Eigen::Matrix<double, Eigen::Dynamic, 1>(num_unique_entities);
             stan::math::fill(num_obs_in_unique_entity, DUMMY_VAR__);
-            current_statement_begin__ = 715;
+            current_statement_begin__ = 716;
             validate_non_negative_index("unique_entity_prop", "std::max(1, num_unique_entities)", std::max(1, num_unique_entities));
             unique_entity_prop = Eigen::Matrix<double, Eigen::Dynamic, 1>(std::max(1, num_unique_entities));
             stan::math::fill(unique_entity_prop, DUMMY_VAR__);
-            current_statement_begin__ = 717;
+            current_statement_begin__ = 718;
             validate_non_negative_index("num_unique_entities_in_estimand_level_entities", "sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list()), \"level_size\"))", sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list()), "level_size")));
             num_unique_entities_in_estimand_level_entities = std::vector<int>(sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list()), "level_size")), int(0));
             stan::math::fill(num_unique_entities_in_estimand_level_entities, std::numeric_limits<int>::min());
             stan::math::assign(num_unique_entities_in_estimand_level_entities,calculate_num_in_level_entities(stan::model::rvalue(unique_entity_ids, stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list())), "unique_entity_ids"), stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list()), "level_size"), pstream__));
-            current_statement_begin__ = 720;
+            current_statement_begin__ = 721;
             validate_non_negative_index("unique_entities_in_level_entities", "num_unique_entities", num_unique_entities);
             validate_non_negative_index("unique_entities_in_level_entities", "num_levels", num_levels);
             unique_entities_in_level_entities = std::vector<std::vector<int> >(num_unique_entities, std::vector<int>(num_levels, int(0)));
             stan::math::fill(unique_entities_in_level_entities, std::numeric_limits<int>::min());
-            current_statement_begin__ = 725;
+            current_statement_begin__ = 726;
             validate_non_negative_index("vec_diff", "((num_diff_estimands * 2) * num_unique_entities)", ((num_diff_estimands * 2) * num_unique_entities));
             vec_diff = Eigen::Matrix<double, Eigen::Dynamic, 1>(((num_diff_estimands * 2) * num_unique_entities));
             stan::math::fill(vec_diff, DUMMY_VAR__);
             stan::math::assign(vec_diff,to_vector(rep_matrix(transpose(stan::math::to_row_vector(stan::math::array_builder<double >().add(1).add(-(1)).array())), (num_diff_estimands * num_unique_entities))));
-            current_statement_begin__ = 726;
+            current_statement_begin__ = 727;
             validate_non_negative_index("vec_mean_diff", "((num_mean_diff_estimands * 2) * num_unique_entities)", ((num_mean_diff_estimands * 2) * num_unique_entities));
             vec_mean_diff = Eigen::Matrix<double, Eigen::Dynamic, 1>(((num_mean_diff_estimands * 2) * num_unique_entities));
             stan::math::fill(vec_mean_diff, DUMMY_VAR__);
             stan::math::assign(vec_mean_diff,to_vector(rep_matrix(transpose(stan::math::to_row_vector(stan::math::array_builder<double >().add(1).add(-(1)).array())), (num_mean_diff_estimands * num_unique_entities))));
-            current_statement_begin__ = 727;
+            current_statement_begin__ = 728;
             validate_non_negative_index("vec_utility_diff", "((num_utility_diff_estimands * 2) * num_unique_entities)", ((num_utility_diff_estimands * 2) * num_unique_entities));
             vec_utility_diff = Eigen::Matrix<double, Eigen::Dynamic, 1>(((num_utility_diff_estimands * 2) * num_unique_entities));
             stan::math::fill(vec_utility_diff, DUMMY_VAR__);
             stan::math::assign(vec_utility_diff,to_vector(rep_matrix(transpose(stan::math::to_row_vector(stan::math::array_builder<double >().add(1).add(-(1)).array())), (num_utility_diff_estimands * num_unique_entities))));
-            current_statement_begin__ = 729;
+            current_statement_begin__ = 730;
             vec_1_size = int(0);
             stan::math::fill(vec_1_size, std::numeric_limits<int>::min());
             stan::math::assign(vec_1_size,max(static_cast<std::vector<int> >(stan::math::array_builder<int >().add(sum(stan::model::rvalue(candidate_group_size, stan::model::cons_list(stan::model::index_multi(unique_entity_candidate_groups), stan::model::nil_index_list()), "candidate_group_size"))).add(sum(stan::model::rvalue(candidate_group_size, stan::model::cons_list(stan::model::index_multi(obs_candidate_group), stan::model::nil_index_list()), "candidate_group_size"))).add((num_unique_entities * sum(abducted_prob_size))).add((num_unique_entities * sum(est_prob_size))).add((num_unique_entities * num_r_types)).array())));
-            current_statement_begin__ = 734;
+            current_statement_begin__ = 735;
             validate_non_negative_index("vec_1", "vec_1_size", vec_1_size);
             vec_1 = Eigen::Matrix<double, Eigen::Dynamic, 1>(vec_1_size);
             stan::math::fill(vec_1, DUMMY_VAR__);
             stan::math::assign(vec_1,rep_vector(1, vec_1_size));
-            current_statement_begin__ = 736;
+            current_statement_begin__ = 737;
             validate_non_negative_index("entity_total_num_candidates", "(logical_gt(num_obs, 0) ? num_unique_entities : 0 )", (logical_gt(num_obs, 0) ? num_unique_entities : 0 ));
             entity_total_num_candidates = std::vector<int>((logical_gt(num_obs, 0) ? num_unique_entities : 0 ), int(0));
             stan::math::fill(entity_total_num_candidates, std::numeric_limits<int>::min());
             stan::math::assign(entity_total_num_candidates,calculate_entity_total_num_candidates(num_unique_entity_candidate_groups, unique_entity_candidate_groups, candidate_group_size, pstream__));
-            current_statement_begin__ = 745;
+            current_statement_begin__ = 746;
             validate_non_negative_index("entity_candidate_group_ids", "sum(entity_total_num_candidates)", sum(entity_total_num_candidates));
             entity_candidate_group_ids = std::vector<int>(sum(entity_total_num_candidates), int(0));
             stan::math::fill(entity_candidate_group_ids, std::numeric_limits<int>::min());
-            current_statement_begin__ = 746;
+            current_statement_begin__ = 747;
             validate_non_negative_index("entity_candidate_group_csr_row_pos", "(sum(num_unique_entity_candidate_groups) + 1)", (sum(num_unique_entity_candidate_groups) + 1));
             entity_candidate_group_csr_row_pos = std::vector<int>((sum(num_unique_entity_candidate_groups) + 1), int(0));
             stan::math::fill(entity_candidate_group_csr_row_pos, std::numeric_limits<int>::min());
-            current_statement_begin__ = 748;
+            current_statement_begin__ = 749;
             validate_non_negative_index("obs_candidate_group_ids", "sum(stan::model::rvalue(candidate_group_size, stan::model::cons_list(stan::model::index_multi(obs_candidate_group), stan::model::nil_index_list()), \"candidate_group_size\"))", sum(stan::model::rvalue(candidate_group_size, stan::model::cons_list(stan::model::index_multi(obs_candidate_group), stan::model::nil_index_list()), "candidate_group_size")));
             obs_candidate_group_ids = std::vector<int>(sum(stan::model::rvalue(candidate_group_size, stan::model::cons_list(stan::model::index_multi(obs_candidate_group), stan::model::nil_index_list()), "candidate_group_size")), int(0));
             stan::math::fill(obs_candidate_group_ids, std::numeric_limits<int>::min());
-            current_statement_begin__ = 749;
+            current_statement_begin__ = 750;
             validate_non_negative_index("obs_candidate_group_csr_row_pos", "(num_obs + 1)", (num_obs + 1));
             obs_candidate_group_csr_row_pos = std::vector<int>((num_obs + 1), int(0));
             stan::math::fill(obs_candidate_group_csr_row_pos, std::numeric_limits<int>::min());
-            current_statement_begin__ = 751;
+            current_statement_begin__ = 752;
             validate_non_negative_index("entity_abducted_prob_ids", "(sum(abducted_prob_size) * num_unique_entities)", (sum(abducted_prob_size) * num_unique_entities));
             entity_abducted_prob_ids = std::vector<int>((sum(abducted_prob_size) * num_unique_entities), int(0));
             stan::math::fill(entity_abducted_prob_ids, std::numeric_limits<int>::min());
-            current_statement_begin__ = 752;
+            current_statement_begin__ = 753;
             validate_non_negative_index("entity_abducted_prob_csr_row_pos", "(num_abducted_estimands ? ((num_unique_entities * num_abducted_estimands) + 1) : 0 )", (num_abducted_estimands ? ((num_unique_entities * num_abducted_estimands) + 1) : 0 ));
             entity_abducted_prob_csr_row_pos = std::vector<int>((num_abducted_estimands ? ((num_unique_entities * num_abducted_estimands) + 1) : 0 ), int(0));
             stan::math::fill(entity_abducted_prob_csr_row_pos, std::numeric_limits<int>::min());
-            current_statement_begin__ = 754;
+            current_statement_begin__ = 755;
             validate_non_negative_index("long_entity_abducted_index", "(num_unique_entities * num_abducted_estimands)", (num_unique_entities * num_abducted_estimands));
             long_entity_abducted_index = std::vector<int>((num_unique_entities * num_abducted_estimands), int(0));
             stan::math::fill(long_entity_abducted_index, std::numeric_limits<int>::min());
-            current_statement_begin__ = 756;
+            current_statement_begin__ = 757;
             validate_non_negative_index("entity_est_prob_ids", "(sum(est_prob_size) * num_unique_entities)", (sum(est_prob_size) * num_unique_entities));
             entity_est_prob_ids = std::vector<int>((sum(est_prob_size) * num_unique_entities), int(0));
             stan::math::fill(entity_est_prob_ids, std::numeric_limits<int>::min());
-            current_statement_begin__ = 757;
+            current_statement_begin__ = 758;
             validate_non_negative_index("entity_est_prob_csr_row_pos", "(logical_gt(num_atom_estimands, 0) ? ((num_unique_entities * num_atom_estimands) + 1) : 0 )", (logical_gt(num_atom_estimands, 0) ? ((num_unique_entities * num_atom_estimands) + 1) : 0 ));
             entity_est_prob_csr_row_pos = std::vector<int>((logical_gt(num_atom_estimands, 0) ? ((num_unique_entities * num_atom_estimands) + 1) : 0 ), int(0));
             stan::math::fill(entity_est_prob_csr_row_pos, std::numeric_limits<int>::min());
-            current_statement_begin__ = 759;
+            current_statement_begin__ = 760;
             validate_non_negative_index("entity_diff_estimand_ids", "((num_diff_estimands * 2) * num_unique_entities)", ((num_diff_estimands * 2) * num_unique_entities));
             entity_diff_estimand_ids = std::vector<int>(((num_diff_estimands * 2) * num_unique_entities), int(0));
             stan::math::fill(entity_diff_estimand_ids, std::numeric_limits<int>::min());
-            current_statement_begin__ = 760;
+            current_statement_begin__ = 761;
             validate_non_negative_index("entity_diff_estimand_csr_row_pos", "(logical_gt(num_diff_estimands, 0) ? ((num_unique_entities * num_diff_estimands) + 1) : 0 )", (logical_gt(num_diff_estimands, 0) ? ((num_unique_entities * num_diff_estimands) + 1) : 0 ));
             entity_diff_estimand_csr_row_pos = std::vector<int>((logical_gt(num_diff_estimands, 0) ? ((num_unique_entities * num_diff_estimands) + 1) : 0 ), int(0));
             stan::math::fill(entity_diff_estimand_csr_row_pos, std::numeric_limits<int>::min());
-            current_statement_begin__ = 762;
+            current_statement_begin__ = 763;
             validate_non_negative_index("entity_mean_diff_estimand_ids", "((num_mean_diff_estimands * 2) * num_unique_entities)", ((num_mean_diff_estimands * 2) * num_unique_entities));
             entity_mean_diff_estimand_ids = std::vector<int>(((num_mean_diff_estimands * 2) * num_unique_entities), int(0));
             stan::math::fill(entity_mean_diff_estimand_ids, std::numeric_limits<int>::min());
-            current_statement_begin__ = 763;
+            current_statement_begin__ = 764;
             validate_non_negative_index("entity_mean_diff_estimand_csr_row_pos", "(logical_gt(num_mean_diff_estimands, 0) ? ((num_unique_entities * num_mean_diff_estimands) + 1) : 0 )", (logical_gt(num_mean_diff_estimands, 0) ? ((num_unique_entities * num_mean_diff_estimands) + 1) : 0 ));
             entity_mean_diff_estimand_csr_row_pos = std::vector<int>((logical_gt(num_mean_diff_estimands, 0) ? ((num_unique_entities * num_mean_diff_estimands) + 1) : 0 ), int(0));
             stan::math::fill(entity_mean_diff_estimand_csr_row_pos, std::numeric_limits<int>::min());
-            current_statement_begin__ = 765;
+            current_statement_begin__ = 766;
             validate_non_negative_index("entity_utility_diff_estimand_ids", "((num_utility_diff_estimands * 2) * num_unique_entities)", ((num_utility_diff_estimands * 2) * num_unique_entities));
             entity_utility_diff_estimand_ids = std::vector<int>(((num_utility_diff_estimands * 2) * num_unique_entities), int(0));
             stan::math::fill(entity_utility_diff_estimand_ids, std::numeric_limits<int>::min());
-            current_statement_begin__ = 766;
+            current_statement_begin__ = 767;
             validate_non_negative_index("entity_utility_diff_estimand_csr_row_pos", "(logical_gt(num_utility_diff_estimands, 0) ? ((num_unique_entities * num_utility_diff_estimands) + 1) : 0 )", (logical_gt(num_utility_diff_estimands, 0) ? ((num_unique_entities * num_utility_diff_estimands) + 1) : 0 ));
             entity_utility_diff_estimand_csr_row_pos = std::vector<int>((logical_gt(num_utility_diff_estimands, 0) ? ((num_unique_entities * num_utility_diff_estimands) + 1) : 0 ), int(0));
             stan::math::fill(entity_utility_diff_estimand_csr_row_pos, std::numeric_limits<int>::min());
-            current_statement_begin__ = 768;
+            current_statement_begin__ = 769;
             validate_non_negative_index("discrete_marginal_prob_csr_vec", "((num_discrete_r_types * num_joint_discrete_combo_members) * num_unique_entities)", ((num_discrete_r_types * num_joint_discrete_combo_members) * num_unique_entities));
             discrete_marginal_prob_csr_vec = Eigen::Matrix<double, Eigen::Dynamic, 1>(((num_discrete_r_types * num_joint_discrete_combo_members) * num_unique_entities));
             stan::math::fill(discrete_marginal_prob_csr_vec, DUMMY_VAR__);
-            current_statement_begin__ = 769;
+            current_statement_begin__ = 770;
             validate_non_negative_index("entity_discrete_marginal_prob_ids", "((num_discrete_r_types * num_joint_discrete_combo_members) * num_unique_entities)", ((num_discrete_r_types * num_joint_discrete_combo_members) * num_unique_entities));
             entity_discrete_marginal_prob_ids = std::vector<int>(((num_discrete_r_types * num_joint_discrete_combo_members) * num_unique_entities), int(0));
             stan::math::fill(entity_discrete_marginal_prob_ids, std::numeric_limits<int>::min());
-            current_statement_begin__ = 770;
+            current_statement_begin__ = 771;
             validate_non_negative_index("entity_discrete_marginal_prob_csr_row_pos", "(num_discrete_r_types + 1)", (num_discrete_r_types + 1));
             entity_discrete_marginal_prob_csr_row_pos = std::vector<int>((num_discrete_r_types + 1), int(0));
             stan::math::fill(entity_discrete_marginal_prob_csr_row_pos, std::numeric_limits<int>::min());
-            current_statement_begin__ = 772;
+            current_statement_begin__ = 773;
             total_num_discrete_bg_variable_types = int(0);
             stan::math::fill(total_num_discrete_bg_variable_types, std::numeric_limits<int>::min());
             stan::math::assign(total_num_discrete_bg_variable_types,sum(num_discrete_bg_variable_types));
-            current_statement_begin__ = 774;
+            current_statement_begin__ = 775;
             validate_non_negative_index("single_discrete_marginal_prob_csr_vec", "(sum(num_discrete_bg_variable_type_combo_members) * num_unique_entities)", (sum(num_discrete_bg_variable_type_combo_members) * num_unique_entities));
             single_discrete_marginal_prob_csr_vec = Eigen::Matrix<double, Eigen::Dynamic, 1>((sum(num_discrete_bg_variable_type_combo_members) * num_unique_entities));
             stan::math::fill(single_discrete_marginal_prob_csr_vec, DUMMY_VAR__);
-            current_statement_begin__ = 775;
+            current_statement_begin__ = 776;
             validate_non_negative_index("entity_single_discrete_marginal_prob_ids", "(sum(num_discrete_bg_variable_type_combo_members) * num_unique_entities)", (sum(num_discrete_bg_variable_type_combo_members) * num_unique_entities));
             entity_single_discrete_marginal_prob_ids = std::vector<int>((sum(num_discrete_bg_variable_type_combo_members) * num_unique_entities), int(0));
             stan::math::fill(entity_single_discrete_marginal_prob_ids, std::numeric_limits<int>::min());
-            current_statement_begin__ = 776;
+            current_statement_begin__ = 777;
             validate_non_negative_index("entity_single_discrete_marginal_prob_csr_row_pos", "(total_num_discrete_bg_variable_types + 1)", (total_num_discrete_bg_variable_types + 1));
             entity_single_discrete_marginal_prob_csr_row_pos = std::vector<int>((total_num_discrete_bg_variable_types + 1), int(0));
             stan::math::fill(entity_single_discrete_marginal_prob_csr_row_pos, std::numeric_limits<int>::min());
-            current_statement_begin__ = 778;
+            current_statement_begin__ = 779;
             validate_non_negative_index("discretized_marginal_prob_csr_vec", "(sum(num_discretized_bg_variable_type_combo_members) * num_unique_entities)", (sum(num_discretized_bg_variable_type_combo_members) * num_unique_entities));
             discretized_marginal_prob_csr_vec = Eigen::Matrix<double, Eigen::Dynamic, 1>((sum(num_discretized_bg_variable_type_combo_members) * num_unique_entities));
             stan::math::fill(discretized_marginal_prob_csr_vec, DUMMY_VAR__);
-            current_statement_begin__ = 779;
+            current_statement_begin__ = 780;
             validate_non_negative_index("entity_discretized_marginal_prob_ids", "(sum(num_discretized_bg_variable_type_combo_members) * num_unique_entities)", (sum(num_discretized_bg_variable_type_combo_members) * num_unique_entities));
             entity_discretized_marginal_prob_ids = std::vector<int>((sum(num_discretized_bg_variable_type_combo_members) * num_unique_entities), int(0));
             stan::math::fill(entity_discretized_marginal_prob_ids, std::numeric_limits<int>::min());
-            current_statement_begin__ = 780;
+            current_statement_begin__ = 781;
             validate_non_negative_index("entity_discretized_marginal_prob_csr_row_pos", "(logical_gt(total_num_discretized_bg_variable_types, 0) ? (total_num_discretized_bg_variable_types + 1) : 0 )", (logical_gt(total_num_discretized_bg_variable_types, 0) ? (total_num_discretized_bg_variable_types + 1) : 0 ));
             entity_discretized_marginal_prob_csr_row_pos = std::vector<int>((logical_gt(total_num_discretized_bg_variable_types, 0) ? (total_num_discretized_bg_variable_types + 1) : 0 ), int(0));
             stan::math::fill(entity_discretized_marginal_prob_csr_row_pos, std::numeric_limits<int>::min());
-            current_statement_begin__ = 782;
+            current_statement_begin__ = 783;
             validate_non_negative_index("level_estimands_csr_vec", "((num_all_estimands * num_unique_entities) * num_estimand_levels)", ((num_all_estimands * num_unique_entities) * num_estimand_levels));
             level_estimands_csr_vec = Eigen::Matrix<double, Eigen::Dynamic, 1>(((num_all_estimands * num_unique_entities) * num_estimand_levels));
             stan::math::fill(level_estimands_csr_vec, DUMMY_VAR__);
-            current_statement_begin__ = 783;
+            current_statement_begin__ = 784;
             validate_non_negative_index("entity_estimand_ids", "((num_all_estimands * num_unique_entities) * num_estimand_levels)", ((num_all_estimands * num_unique_entities) * num_estimand_levels));
             entity_estimand_ids = std::vector<int>(((num_all_estimands * num_unique_entities) * num_estimand_levels), int(0));
             stan::math::fill(entity_estimand_ids, std::numeric_limits<int>::min());
-            current_statement_begin__ = 784;
+            current_statement_begin__ = 785;
             validate_non_negative_index("entity_estimand_csr_row_pos", "(logical_gt(num_estimand_levels, 0) ? ((num_all_estimands * sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list()), \"level_size\"))) + 1) : 0 )", (logical_gt(num_estimand_levels, 0) ? ((num_all_estimands * sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list()), "level_size"))) + 1) : 0 ));
             entity_estimand_csr_row_pos = std::vector<int>((logical_gt(num_estimand_levels, 0) ? ((num_all_estimands * sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list()), "level_size"))) + 1) : 0 ), int(0));
             stan::math::fill(entity_estimand_csr_row_pos, std::numeric_limits<int>::min());
-            current_statement_begin__ = 786;
+            current_statement_begin__ = 787;
             validate_non_negative_index("entity_histogram_vec", "((num_discretized_groups * ((2 * num_discretized_variables) + 1)) * num_unique_entities)", ((num_discretized_groups * ((2 * num_discretized_variables) + 1)) * num_unique_entities));
             entity_histogram_vec = Eigen::Matrix<double, Eigen::Dynamic, 1>(((num_discretized_groups * ((2 * num_discretized_variables) + 1)) * num_unique_entities));
             stan::math::fill(entity_histogram_vec, DUMMY_VAR__);
-            current_statement_begin__ = 787;
+            current_statement_begin__ = 788;
             validate_non_negative_index("entity_histogram_ids", "((num_discretized_groups * ((2 * num_discretized_variables) + 1)) * num_unique_entities)", ((num_discretized_groups * ((2 * num_discretized_variables) + 1)) * num_unique_entities));
             entity_histogram_ids = std::vector<int>(((num_discretized_groups * ((2 * num_discretized_variables) + 1)) * num_unique_entities), int(0));
             stan::math::fill(entity_histogram_ids, std::numeric_limits<int>::min());
-            current_statement_begin__ = 788;
+            current_statement_begin__ = 789;
             validate_non_negative_index("entity_histogram_csr_row_pos", "(logical_gt(num_discretized_groups, 0) ? (((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities) + 1) : 0 )", (logical_gt(num_discretized_groups, 0) ? (((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities) + 1) : 0 ));
             entity_histogram_csr_row_pos = std::vector<int>((logical_gt(num_discretized_groups, 0) ? (((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities) + 1) : 0 ), int(0));
             stan::math::fill(entity_histogram_csr_row_pos, std::numeric_limits<int>::min());
-            current_statement_begin__ = 790;
+            current_statement_begin__ = 791;
             validate_non_negative_index("entity_midpoint_vec", "((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities)", ((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities));
             entity_midpoint_vec = Eigen::Matrix<double, Eigen::Dynamic, 1>(((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities));
             stan::math::fill(entity_midpoint_vec, DUMMY_VAR__);
-            current_statement_begin__ = 791;
+            current_statement_begin__ = 792;
             validate_non_negative_index("entity_midpoint_ids", "((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities)", ((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities));
             entity_midpoint_ids = std::vector<int>(((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities), int(0));
             stan::math::fill(entity_midpoint_ids, std::numeric_limits<int>::min());
-            current_statement_begin__ = 792;
+            current_statement_begin__ = 793;
             validate_non_negative_index("entity_midpoint_csr_row_pos", "(logical_gt(num_discretized_groups, 0) ? ((num_discretized_groups * num_unique_entities) + 1) : 0 )", (logical_gt(num_discretized_groups, 0) ? ((num_discretized_groups * num_unique_entities) + 1) : 0 ));
             entity_midpoint_csr_row_pos = std::vector<int>((logical_gt(num_discretized_groups, 0) ? ((num_discretized_groups * num_unique_entities) + 1) : 0 ), int(0));
             stan::math::fill(entity_midpoint_csr_row_pos, std::numeric_limits<int>::min());
-            current_statement_begin__ = 794;
+            current_statement_begin__ = 795;
             validate_non_negative_index("entity_utility_vec", "(logical_gt(num_discrete_utility_values, 0) ? ((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities) : 0 )", (logical_gt(num_discrete_utility_values, 0) ? ((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities) : 0 ));
             entity_utility_vec = Eigen::Matrix<double, Eigen::Dynamic, 1>((logical_gt(num_discrete_utility_values, 0) ? ((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities) : 0 ));
             stan::math::fill(entity_utility_vec, DUMMY_VAR__);
-            current_statement_begin__ = 796;
+            current_statement_begin__ = 797;
             validate_non_negative_index("between_entity_diff_csr_vec", "((2 * num_atom_estimands) * (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), \"level_size\")) - num_between_entity_diff_levels))", ((2 * num_atom_estimands) * (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), "level_size")) - num_between_entity_diff_levels)));
             between_entity_diff_csr_vec = Eigen::Matrix<double, Eigen::Dynamic, 1>(((2 * num_atom_estimands) * (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), "level_size")) - num_between_entity_diff_levels)));
             stan::math::fill(between_entity_diff_csr_vec, DUMMY_VAR__);
             stan::math::assign(between_entity_diff_csr_vec,to_vector(rep_matrix(transpose(stan::math::to_row_vector(stan::math::array_builder<double >().add(-(1)).add(1).array())), (num_atom_estimands * (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), "level_size")) - num_between_entity_diff_levels)))));
-            current_statement_begin__ = 798;
+            current_statement_begin__ = 799;
             validate_non_negative_index("between_entity_diff_csr_ids", "((2 * num_atom_estimands) * (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), \"level_size\")) - num_between_entity_diff_levels))", ((2 * num_atom_estimands) * (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), "level_size")) - num_between_entity_diff_levels)));
             between_entity_diff_csr_ids = std::vector<int>(((2 * num_atom_estimands) * (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), "level_size")) - num_between_entity_diff_levels)), int(0));
             stan::math::fill(between_entity_diff_csr_ids, std::numeric_limits<int>::min());
-            current_statement_begin__ = 799;
+            current_statement_begin__ = 800;
             validate_non_negative_index("between_entity_diff_csr_row_pos", "(logical_gt(num_between_entity_diff_levels, 0) ? ((num_atom_estimands * (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), \"level_size\")) - num_between_entity_diff_levels)) + 1) : 0 )", (logical_gt(num_between_entity_diff_levels, 0) ? ((num_atom_estimands * (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), "level_size")) - num_between_entity_diff_levels)) + 1) : 0 ));
             between_entity_diff_csr_row_pos = std::vector<int>((logical_gt(num_between_entity_diff_levels, 0) ? ((num_atom_estimands * (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), "level_size")) - num_between_entity_diff_levels)) + 1) : 0 ), int(0));
             stan::math::fill(between_entity_diff_csr_row_pos, std::numeric_limits<int>::min());
             // execute transformed data statements
-            current_statement_begin__ = 809;
+            current_statement_begin__ = 810;
             for (int cutpoint_index = 2; cutpoint_index <= num_cutpoints; ++cutpoint_index) {
-                current_statement_begin__ = 810;
+                current_statement_begin__ = 811;
                 stan::model::assign(cutpoint_midpoints, 
                             stan::model::cons_list(stan::model::index_uni((cutpoint_index - 1)), stan::model::nil_index_list()), 
                             mean(stan::model::rvalue(cutpoints, stan::model::cons_list(stan::model::index_min_max((cutpoint_index - 1), cutpoint_index), stan::model::nil_index_list()), "cutpoints")), 
                             "assigning variable cutpoint_midpoints");
-                current_statement_begin__ = 812;
+                current_statement_begin__ = 813;
                 stan::model::assign(discretized_binwidth, 
                             stan::model::cons_list(stan::model::index_uni((cutpoint_index - 1)), stan::model::nil_index_list()), 
                             (get_base1(cutpoints, cutpoint_index, "cutpoints", 1) - get_base1(cutpoints, (cutpoint_index - 1), "cutpoints", 1)), 
                             "assigning variable discretized_binwidth");
-                current_statement_begin__ = 814;
+                current_statement_begin__ = 815;
                 stan::model::assign(discretize_bin_alpha, 
                             stan::model::cons_list(stan::model::index_uni((cutpoint_index - 1)), stan::model::nil_index_list()), 
                             get_base1(cutpoints, (cutpoint_index - 1), "cutpoints", 1), 
                             "assigning variable discretize_bin_alpha");
-                current_statement_begin__ = 815;
+                current_statement_begin__ = 816;
                 stan::model::assign(discretize_bin_beta, 
                             stan::model::cons_list(stan::model::index_uni((cutpoint_index - 1)), stan::model::nil_index_list()), 
                             get_base1(cutpoints, cutpoint_index, "cutpoints", 1), 
                             "assigning variable discretize_bin_beta");
             }
-            current_statement_begin__ = 818;
+            current_statement_begin__ = 819;
             for (int level_index = 1; level_index <= num_levels; ++level_index) {
-                current_statement_begin__ = 819;
+                current_statement_begin__ = 820;
                 stan::model::assign(unique_entities_in_level_entities, 
                             stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(level_index), stan::model::nil_index_list())), 
                             sort_indices_asc(stan::model::rvalue(unique_entity_ids, stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(level_index), stan::model::nil_index_list())), "unique_entity_ids")), 
                             "assigning variable unique_entities_in_level_entities");
             }
-            current_statement_begin__ = 822;
+            current_statement_begin__ = 823;
             if (as_bool(logical_gt(num_abducted_estimands, 0))) {
-                current_statement_begin__ = 823;
-                stan::math::assign(entity_abducted_prob_ids, csr_shift_expand_v(abducted_prob_index, num_r_types_full, num_unique_entities, pstream__));
                 current_statement_begin__ = 824;
+                stan::math::assign(entity_abducted_prob_ids, csr_shift_expand_v(abducted_prob_index, num_r_types_full, num_unique_entities, pstream__));
+                current_statement_begin__ = 825;
                 stan::math::assign(entity_abducted_prob_csr_row_pos, csr_shift_expand_u(abducted_prob_size, num_unique_entities, pstream__));
             }
-            current_statement_begin__ = 827;
+            current_statement_begin__ = 828;
             if (as_bool(logical_gt(num_atom_estimands, 0))) {
-                current_statement_begin__ = 828;
-                stan::math::assign(entity_est_prob_ids, csr_shift_expand_v(est_prob_index, num_r_types_full, num_unique_entities, pstream__));
                 current_statement_begin__ = 829;
+                stan::math::assign(entity_est_prob_ids, csr_shift_expand_v(est_prob_index, num_r_types_full, num_unique_entities, pstream__));
+                current_statement_begin__ = 830;
                 stan::math::assign(entity_est_prob_csr_row_pos, csr_shift_expand_u(est_prob_size, num_unique_entities, pstream__));
             }
-            current_statement_begin__ = 832;
+            current_statement_begin__ = 833;
             if (as_bool(logical_gt(num_diff_estimands, 0))) {
-                current_statement_begin__ = 833;
-                stan::math::assign(entity_diff_estimand_ids, csr_shift_expand_v(diff_estimand_atoms, num_atom_estimands, num_unique_entities, pstream__));
                 current_statement_begin__ = 834;
+                stan::math::assign(entity_diff_estimand_ids, csr_shift_expand_v(diff_estimand_atoms, num_atom_estimands, num_unique_entities, pstream__));
+                current_statement_begin__ = 835;
                 stan::math::assign(entity_diff_estimand_csr_row_pos, csr_shift_expand_u(rep_array(2, num_diff_estimands), num_unique_entities, pstream__));
             }
-            current_statement_begin__ = 837;
+            current_statement_begin__ = 838;
             if (as_bool(logical_gt(num_mean_diff_estimands, 0))) {
-                current_statement_begin__ = 838;
-                stan::math::assign(entity_mean_diff_estimand_ids, csr_shift_expand_v(mean_diff_estimand_atoms, num_discretized_groups, num_unique_entities, pstream__));
                 current_statement_begin__ = 839;
+                stan::math::assign(entity_mean_diff_estimand_ids, csr_shift_expand_v(mean_diff_estimand_atoms, num_discretized_groups, num_unique_entities, pstream__));
+                current_statement_begin__ = 840;
                 stan::math::assign(entity_mean_diff_estimand_csr_row_pos, csr_shift_expand_u(rep_array(2, num_mean_diff_estimands), num_unique_entities, pstream__));
             }
-            current_statement_begin__ = 842;
+            current_statement_begin__ = 843;
             if (as_bool(logical_gt(num_utility_diff_estimands, 0))) {
-                current_statement_begin__ = 843;
-                stan::math::assign(entity_utility_diff_estimand_ids, csr_shift_expand_v(utility_diff_estimand_atoms, num_discretized_groups, num_unique_entities, pstream__));
                 current_statement_begin__ = 844;
+                stan::math::assign(entity_utility_diff_estimand_ids, csr_shift_expand_v(utility_diff_estimand_atoms, num_discretized_groups, num_unique_entities, pstream__));
+                current_statement_begin__ = 845;
                 stan::math::assign(entity_utility_diff_estimand_csr_row_pos, csr_shift_expand_u(rep_array(2, num_utility_diff_estimands), num_unique_entities, pstream__));
             }
-            current_statement_begin__ = 850;
+            current_statement_begin__ = 851;
             if (as_bool(logical_gt(num_obs, 0))) {
                 {
-                current_statement_begin__ = 852;
+                current_statement_begin__ = 853;
                 int entity_candidate_group_pos(0);
                 (void) entity_candidate_group_pos;  // dummy to suppress unused var warning
                 stan::math::fill(entity_candidate_group_pos, std::numeric_limits<int>::min());
                 stan::math::assign(entity_candidate_group_pos,1);
-                current_statement_begin__ = 853;
+                current_statement_begin__ = 854;
                 int entity_candidate_pos(0);
                 (void) entity_candidate_pos;  // dummy to suppress unused var warning
                 stan::math::fill(entity_candidate_pos, std::numeric_limits<int>::min());
                 stan::math::assign(entity_candidate_pos,1);
-                current_statement_begin__ = 854;
+                current_statement_begin__ = 855;
                 int entity_candidate_group_csr_row_pos_pos(0);
                 (void) entity_candidate_group_csr_row_pos_pos;  // dummy to suppress unused var warning
                 stan::math::fill(entity_candidate_group_csr_row_pos_pos, std::numeric_limits<int>::min());
                 stan::math::assign(entity_candidate_group_csr_row_pos_pos,1);
-                current_statement_begin__ = 855;
+                current_statement_begin__ = 856;
                 int last_candidate_group_size(0);
                 (void) last_candidate_group_size;  // dummy to suppress unused var warning
                 stan::math::fill(last_candidate_group_size, std::numeric_limits<int>::min());
-                current_statement_begin__ = 857;
+                current_statement_begin__ = 858;
                 int long_entity_abducted_index_pos(0);
                 (void) long_entity_abducted_index_pos;  // dummy to suppress unused var warning
                 stan::math::fill(long_entity_abducted_index_pos, std::numeric_limits<int>::min());
                 stan::math::assign(long_entity_abducted_index_pos,1);
-                current_statement_begin__ = 859;
+                current_statement_begin__ = 860;
                 for (int entity_index = 1; entity_index <= num_unique_entities; ++entity_index) {
                     {
-                    current_statement_begin__ = 860;
+                    current_statement_begin__ = 861;
                     int num_entity_candidate_groups(0);
                     (void) num_entity_candidate_groups;  // dummy to suppress unused var warning
                     stan::math::fill(num_entity_candidate_groups, std::numeric_limits<int>::min());
                     stan::math::assign(num_entity_candidate_groups,get_base1(num_unique_entity_candidate_groups, entity_index, "num_unique_entity_candidate_groups", 1));
-                    current_statement_begin__ = 861;
+                    current_statement_begin__ = 862;
                     int entity_candidate_group_end(0);
                     (void) entity_candidate_group_end;  // dummy to suppress unused var warning
                     stan::math::fill(entity_candidate_group_end, std::numeric_limits<int>::min());
                     stan::math::assign(entity_candidate_group_end,((entity_candidate_group_pos + num_entity_candidate_groups) - 1));
-                    current_statement_begin__ = 863;
+                    current_statement_begin__ = 864;
                     validate_non_negative_index("curr_candidate_groups", "num_entity_candidate_groups", num_entity_candidate_groups);
                     std::vector<int  > curr_candidate_groups(num_entity_candidate_groups, int(0));
                     stan::math::fill(curr_candidate_groups, std::numeric_limits<int>::min());
                     stan::math::assign(curr_candidate_groups,stan::model::rvalue(unique_entity_candidate_groups, stan::model::cons_list(stan::model::index_min_max(entity_candidate_group_pos, entity_candidate_group_end), stan::model::nil_index_list()), "unique_entity_candidate_groups"));
-                    current_statement_begin__ = 865;
+                    current_statement_begin__ = 866;
                     stan::model::assign(num_obs_in_unique_entity, 
                                 stan::model::cons_list(stan::model::index_uni(entity_index), stan::model::nil_index_list()), 
                                 num_equals(obs_unique_entity_id, static_cast<std::vector<int> >(stan::math::array_builder<int >().add(entity_index).array()), pstream__), 
                                 "assigning variable num_obs_in_unique_entity");
-                    current_statement_begin__ = 867;
+                    current_statement_begin__ = 868;
                     for (int candidate_group_index = 1; candidate_group_index <= num_entity_candidate_groups; ++candidate_group_index) {
                         {
-                        current_statement_begin__ = 868;
+                        current_statement_begin__ = 869;
                         int curr_candidate_group(0);
                         (void) curr_candidate_group;  // dummy to suppress unused var warning
                         stan::math::fill(curr_candidate_group, std::numeric_limits<int>::min());
                         stan::math::assign(curr_candidate_group,get_base1(curr_candidate_groups, candidate_group_index, "curr_candidate_groups", 1));
-                        current_statement_begin__ = 869;
+                        current_statement_begin__ = 870;
                         int candidate_pos(0);
                         (void) candidate_pos;  // dummy to suppress unused var warning
                         stan::math::fill(candidate_pos, std::numeric_limits<int>::min());
                         stan::math::assign(candidate_pos,(logical_gt(curr_candidate_group, 1) ? (sum(stan::model::rvalue(candidate_group_size, stan::model::cons_list(stan::model::index_min_max(1, (curr_candidate_group - 1)), stan::model::nil_index_list()), "candidate_group_size")) + 1) : 1 ));
-                        current_statement_begin__ = 870;
+                        current_statement_begin__ = 871;
                         int candidate_end(0);
                         (void) candidate_end;  // dummy to suppress unused var warning
                         stan::math::fill(candidate_end, std::numeric_limits<int>::min());
                         stan::math::assign(candidate_end,sum(stan::model::rvalue(candidate_group_size, stan::model::cons_list(stan::model::index_min_max(1, curr_candidate_group), stan::model::nil_index_list()), "candidate_group_size")));
-                        current_statement_begin__ = 872;
+                        current_statement_begin__ = 873;
                         int entity_candidate_end(0);
                         (void) entity_candidate_end;  // dummy to suppress unused var warning
                         stan::math::fill(entity_candidate_end, std::numeric_limits<int>::min());
                         stan::math::assign(entity_candidate_end,((entity_candidate_pos + get_base1(candidate_group_size, curr_candidate_group, "candidate_group_size", 1)) - 1));
-                        current_statement_begin__ = 874;
+                        current_statement_begin__ = 875;
                         stan::model::assign(entity_candidate_group_ids, 
                                     stan::model::cons_list(stan::model::index_min_max(entity_candidate_pos, entity_candidate_end), stan::model::nil_index_list()), 
                                     array_add(stan::model::rvalue(candidate_group_ids, stan::model::cons_list(stan::model::index_min_max(candidate_pos, candidate_end), stan::model::nil_index_list()), "candidate_group_ids"), static_cast<std::vector<int> >(stan::math::array_builder<int >().add(((entity_index - 1) * num_r_types)).array()), pstream__), 
                                     "assigning variable entity_candidate_group_ids");
-                        current_statement_begin__ = 876;
+                        current_statement_begin__ = 877;
                         stan::model::assign(entity_candidate_group_csr_row_pos, 
                                     stan::model::cons_list(stan::model::index_uni(entity_candidate_group_csr_row_pos_pos), stan::model::nil_index_list()), 
                                     (logical_gt(entity_candidate_group_csr_row_pos_pos, 1) ? (get_base1(entity_candidate_group_csr_row_pos, (entity_candidate_group_csr_row_pos_pos - 1), "entity_candidate_group_csr_row_pos", 1) + last_candidate_group_size) : 1 ), 
                                     "assigning variable entity_candidate_group_csr_row_pos");
-                        current_statement_begin__ = 880;
+                        current_statement_begin__ = 881;
                         stan::math::assign(last_candidate_group_size, get_base1(stan::model::rvalue(candidate_group_size, stan::model::cons_list(stan::model::index_multi(curr_candidate_groups), stan::model::nil_index_list()), "candidate_group_size"), candidate_group_index, "stan::model::rvalue(candidate_group_size, stan::model::cons_list(stan::model::index_multi(curr_candidate_groups), stan::model::nil_index_list()), \"candidate_group_size\")", 1));
-                        current_statement_begin__ = 882;
-                        stan::math::assign(entity_candidate_pos, (entity_candidate_end + 1));
                         current_statement_begin__ = 883;
+                        stan::math::assign(entity_candidate_pos, (entity_candidate_end + 1));
+                        current_statement_begin__ = 884;
                         stan::math::assign(entity_candidate_group_csr_row_pos_pos, (entity_candidate_group_csr_row_pos_pos + 1));
                         }
                     }
-                    current_statement_begin__ = 886;
+                    current_statement_begin__ = 887;
                     stan::model::assign(entity_candidate_group_csr_row_pos, 
                                 stan::model::cons_list(stan::model::index_uni(entity_candidate_group_csr_row_pos_pos), stan::model::nil_index_list()), 
                                 (get_base1(entity_candidate_group_csr_row_pos, (entity_candidate_group_csr_row_pos_pos - 1), "entity_candidate_group_csr_row_pos", 1) + last_candidate_group_size), 
                                 "assigning variable entity_candidate_group_csr_row_pos");
-                    current_statement_begin__ = 888;
+                    current_statement_begin__ = 889;
                     stan::math::assign(entity_candidate_group_pos, (entity_candidate_group_end + 1));
-                    current_statement_begin__ = 890;
+                    current_statement_begin__ = 891;
                     if (as_bool(logical_gt(num_abducted_estimands, 0))) {
                         {
-                        current_statement_begin__ = 891;
+                        current_statement_begin__ = 892;
                         int long_entity_abducted_index_end(0);
                         (void) long_entity_abducted_index_end;  // dummy to suppress unused var warning
                         stan::math::fill(long_entity_abducted_index_end, std::numeric_limits<int>::min());
                         stan::math::assign(long_entity_abducted_index_end,((long_entity_abducted_index_pos + num_abducted_estimands) - 1));
-                        current_statement_begin__ = 893;
+                        current_statement_begin__ = 894;
                         stan::model::assign(long_entity_abducted_index, 
                                     stan::model::cons_list(stan::model::index_min_max(long_entity_abducted_index_pos, long_entity_abducted_index_end), stan::model::nil_index_list()), 
                                     array_add(abducted_estimand_ids, static_cast<std::vector<int> >(stan::math::array_builder<int >().add(((entity_index - 1) * num_atom_estimands)).array()), pstream__), 
                                     "assigning variable long_entity_abducted_index");
-                        current_statement_begin__ = 895;
+                        current_statement_begin__ = 896;
                         stan::math::assign(long_entity_abducted_index_pos, (long_entity_abducted_index_end + 1));
                         }
                     }
@@ -3325,638 +3336,638 @@ public:
                 }
                 }
                 {
-                current_statement_begin__ = 901;
+                current_statement_begin__ = 902;
                 int obs_candidate_pos(0);
                 (void) obs_candidate_pos;  // dummy to suppress unused var warning
                 stan::math::fill(obs_candidate_pos, std::numeric_limits<int>::min());
                 stan::math::assign(obs_candidate_pos,1);
-                current_statement_begin__ = 902;
+                current_statement_begin__ = 903;
                 int last_candidate_group_size(0);
                 (void) last_candidate_group_size;  // dummy to suppress unused var warning
                 stan::math::fill(last_candidate_group_size, std::numeric_limits<int>::min());
-                current_statement_begin__ = 904;
+                current_statement_begin__ = 905;
                 for (int obs_index = 1; obs_index <= num_obs; ++obs_index) {
                     {
-                    current_statement_begin__ = 905;
+                    current_statement_begin__ = 906;
                     int entity_index(0);
                     (void) entity_index;  // dummy to suppress unused var warning
                     stan::math::fill(entity_index, std::numeric_limits<int>::min());
                     stan::math::assign(entity_index,get_base1(obs_unique_entity_id, obs_index, "obs_unique_entity_id", 1));
-                    current_statement_begin__ = 906;
+                    current_statement_begin__ = 907;
                     int obs_candidate_end(0);
                     (void) obs_candidate_end;  // dummy to suppress unused var warning
                     stan::math::fill(obs_candidate_end, std::numeric_limits<int>::min());
                     stan::math::assign(obs_candidate_end,((obs_candidate_pos + get_base1(candidate_group_size, get_base1(obs_candidate_group, obs_index, "obs_candidate_group", 1), "candidate_group_size", 1)) - 1));
-                    current_statement_begin__ = 908;
+                    current_statement_begin__ = 909;
                     int curr_candidate_group(0);
                     (void) curr_candidate_group;  // dummy to suppress unused var warning
                     stan::math::fill(curr_candidate_group, std::numeric_limits<int>::min());
                     stan::math::assign(curr_candidate_group,get_base1(obs_candidate_group, obs_index, "obs_candidate_group", 1));
-                    current_statement_begin__ = 910;
+                    current_statement_begin__ = 911;
                     int candidate_pos(0);
                     (void) candidate_pos;  // dummy to suppress unused var warning
                     stan::math::fill(candidate_pos, std::numeric_limits<int>::min());
                     stan::math::assign(candidate_pos,(logical_gt(curr_candidate_group, 1) ? (sum(stan::model::rvalue(candidate_group_size, stan::model::cons_list(stan::model::index_min_max(1, (curr_candidate_group - 1)), stan::model::nil_index_list()), "candidate_group_size")) + 1) : 1 ));
-                    current_statement_begin__ = 911;
+                    current_statement_begin__ = 912;
                     int candidate_end(0);
                     (void) candidate_end;  // dummy to suppress unused var warning
                     stan::math::fill(candidate_end, std::numeric_limits<int>::min());
                     stan::math::assign(candidate_end,sum(stan::model::rvalue(candidate_group_size, stan::model::cons_list(stan::model::index_min_max(1, curr_candidate_group), stan::model::nil_index_list()), "candidate_group_size")));
-                    current_statement_begin__ = 913;
+                    current_statement_begin__ = 914;
                     stan::model::assign(obs_candidate_group_ids, 
                                 stan::model::cons_list(stan::model::index_min_max(obs_candidate_pos, obs_candidate_end), stan::model::nil_index_list()), 
                                 array_add(stan::model::rvalue(candidate_group_ids, stan::model::cons_list(stan::model::index_min_max(candidate_pos, candidate_end), stan::model::nil_index_list()), "candidate_group_ids"), static_cast<std::vector<int> >(stan::math::array_builder<int >().add(((entity_index - 1) * num_r_types)).array()), pstream__), 
                                 "assigning variable obs_candidate_group_ids");
-                    current_statement_begin__ = 915;
+                    current_statement_begin__ = 916;
                     stan::model::assign(obs_candidate_group_csr_row_pos, 
                                 stan::model::cons_list(stan::model::index_uni(obs_index), stan::model::nil_index_list()), 
                                 (logical_gt(obs_index, 1) ? (get_base1(obs_candidate_group_csr_row_pos, (obs_index - 1), "obs_candidate_group_csr_row_pos", 1) + last_candidate_group_size) : 1 ), 
                                 "assigning variable obs_candidate_group_csr_row_pos");
-                    current_statement_begin__ = 917;
+                    current_statement_begin__ = 918;
                     stan::math::assign(last_candidate_group_size, get_base1(candidate_group_size, curr_candidate_group, "candidate_group_size", 1));
-                    current_statement_begin__ = 919;
+                    current_statement_begin__ = 920;
                     stan::math::assign(obs_candidate_pos, (obs_candidate_end + 1));
                     }
                 }
-                current_statement_begin__ = 922;
+                current_statement_begin__ = 923;
                 stan::model::assign(obs_candidate_group_csr_row_pos, 
                             stan::model::cons_list(stan::model::index_uni((num_obs + 1)), stan::model::nil_index_list()), 
                             (get_base1(obs_candidate_group_csr_row_pos, num_obs, "obs_candidate_group_csr_row_pos", 1) + last_candidate_group_size), 
                             "assigning variable obs_candidate_group_csr_row_pos");
-                current_statement_begin__ = 924;
+                current_statement_begin__ = 925;
                 stan::math::assign(unique_entity_prop, divide(num_obs_in_unique_entity, num_obs));
                 }
             } else {
-                current_statement_begin__ = 927;
+                current_statement_begin__ = 928;
                 stan::model::assign(obs_candidate_group_csr_row_pos, 
                             stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()), 
                             1, 
                             "assigning variable obs_candidate_group_csr_row_pos");
-                current_statement_begin__ = 929;
+                current_statement_begin__ = 930;
                 stan::math::assign(unique_entity_prop, rep_vector((1.0 / num_unique_entities), num_unique_entities));
-                current_statement_begin__ = 931;
+                current_statement_begin__ = 932;
                 stan::model::assign(entity_candidate_group_csr_row_pos, 
                             stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()), 
                             1, 
                             "assigning variable entity_candidate_group_csr_row_pos");
-                current_statement_begin__ = 933;
+                current_statement_begin__ = 934;
                 stan::math::assign(num_obs_in_unique_entity, rep_vector(0, num_unique_entities));
             }
             {
-            current_statement_begin__ = 937;
+            current_statement_begin__ = 938;
             int discrete_marginal_members_pos(0);
             (void) discrete_marginal_members_pos;  // dummy to suppress unused var warning
             stan::math::fill(discrete_marginal_members_pos, std::numeric_limits<int>::min());
             stan::math::assign(discrete_marginal_members_pos,1);
-            current_statement_begin__ = 938;
+            current_statement_begin__ = 939;
             int entity_discrete_marginal_prob_csr_row_pos_pos(0);
             (void) entity_discrete_marginal_prob_csr_row_pos_pos;  // dummy to suppress unused var warning
             stan::math::fill(entity_discrete_marginal_prob_csr_row_pos_pos, std::numeric_limits<int>::min());
             stan::math::assign(entity_discrete_marginal_prob_csr_row_pos_pos,1);
-            current_statement_begin__ = 939;
+            current_statement_begin__ = 940;
             int entity_discrete_marginal_prob_pos(0);
             (void) entity_discrete_marginal_prob_pos;  // dummy to suppress unused var warning
             stan::math::fill(entity_discrete_marginal_prob_pos, std::numeric_limits<int>::min());
             stan::math::assign(entity_discrete_marginal_prob_pos,1);
-            current_statement_begin__ = 941;
+            current_statement_begin__ = 942;
             for (int joint_discrete_index = 1; joint_discrete_index <= num_discrete_r_types; ++joint_discrete_index) {
                 {
-                current_statement_begin__ = 942;
+                current_statement_begin__ = 943;
                 int discrete_marginal_members_end(0);
                 (void) discrete_marginal_members_end;  // dummy to suppress unused var warning
                 stan::math::fill(discrete_marginal_members_end, std::numeric_limits<int>::min());
                 stan::math::assign(discrete_marginal_members_end,((discrete_marginal_members_pos + num_joint_discrete_combo_members) - 1));
-                current_statement_begin__ = 944;
+                current_statement_begin__ = 945;
                 stan::model::assign(entity_discrete_marginal_prob_csr_row_pos, 
                             stan::model::cons_list(stan::model::index_uni(entity_discrete_marginal_prob_csr_row_pos_pos), stan::model::nil_index_list()), 
                             (logical_gt(entity_discrete_marginal_prob_csr_row_pos_pos, 1) ? (get_base1(entity_discrete_marginal_prob_csr_row_pos, (entity_discrete_marginal_prob_csr_row_pos_pos - 1), "entity_discrete_marginal_prob_csr_row_pos", 1) + (num_joint_discrete_combo_members * num_unique_entities)) : 1 ), 
                             "assigning variable entity_discrete_marginal_prob_csr_row_pos");
-                current_statement_begin__ = 948;
+                current_statement_begin__ = 949;
                 for (int entity_index = 1; entity_index <= num_unique_entities; ++entity_index) {
                     {
-                    current_statement_begin__ = 949;
+                    current_statement_begin__ = 950;
                     local_scalar_t__ entity_prop(DUMMY_VAR__);
                     (void) entity_prop;  // dummy to suppress unused var warning
                     stan::math::initialize(entity_prop, DUMMY_VAR__);
                     stan::math::fill(entity_prop, DUMMY_VAR__);
                     stan::math::assign(entity_prop,(get_base1(num_obs_in_unique_entity, entity_index, "num_obs_in_unique_entity", 1) / std::max(num_obs, 1)));
-                    current_statement_begin__ = 950;
+                    current_statement_begin__ = 951;
                     int entity_discrete_marginal_prob_end(0);
                     (void) entity_discrete_marginal_prob_end;  // dummy to suppress unused var warning
                     stan::math::fill(entity_discrete_marginal_prob_end, std::numeric_limits<int>::min());
                     stan::math::assign(entity_discrete_marginal_prob_end,((entity_discrete_marginal_prob_pos + num_joint_discrete_combo_members) - 1));
-                    current_statement_begin__ = 952;
+                    current_statement_begin__ = 953;
                     stan::model::assign(discrete_marginal_prob_csr_vec, 
                                 stan::model::cons_list(stan::model::index_min_max(entity_discrete_marginal_prob_pos, entity_discrete_marginal_prob_end), stan::model::nil_index_list()), 
                                 rep_vector(entity_prop, num_joint_discrete_combo_members), 
                                 "assigning variable discrete_marginal_prob_csr_vec");
-                    current_statement_begin__ = 954;
+                    current_statement_begin__ = 955;
                     stan::model::assign(entity_discrete_marginal_prob_ids, 
                                 stan::model::cons_list(stan::model::index_min_max(entity_discrete_marginal_prob_pos, entity_discrete_marginal_prob_end), stan::model::nil_index_list()), 
                                 array_add(stan::model::rvalue(joint_discrete_combo_members, stan::model::cons_list(stan::model::index_min_max(discrete_marginal_members_pos, discrete_marginal_members_end), stan::model::nil_index_list()), "joint_discrete_combo_members"), static_cast<std::vector<int> >(stan::math::array_builder<int >().add(((entity_index - 1) * num_r_types)).array()), pstream__), 
                                 "assigning variable entity_discrete_marginal_prob_ids");
-                    current_statement_begin__ = 957;
+                    current_statement_begin__ = 958;
                     stan::math::assign(entity_discrete_marginal_prob_pos, (entity_discrete_marginal_prob_end + 1));
                     }
                 }
-                current_statement_begin__ = 960;
-                stan::math::assign(discrete_marginal_members_pos, (discrete_marginal_members_end + 1));
                 current_statement_begin__ = 961;
+                stan::math::assign(discrete_marginal_members_pos, (discrete_marginal_members_end + 1));
+                current_statement_begin__ = 962;
                 stan::math::assign(entity_discrete_marginal_prob_csr_row_pos_pos, (entity_discrete_marginal_prob_csr_row_pos_pos + 1));
                 }
             }
-            current_statement_begin__ = 964;
+            current_statement_begin__ = 965;
             stan::model::assign(entity_discrete_marginal_prob_csr_row_pos, 
                         stan::model::cons_list(stan::model::index_uni(entity_discrete_marginal_prob_csr_row_pos_pos), stan::model::nil_index_list()), 
                         (get_base1(entity_discrete_marginal_prob_csr_row_pos, (entity_discrete_marginal_prob_csr_row_pos_pos - 1), "entity_discrete_marginal_prob_csr_row_pos", 1) + (num_joint_discrete_combo_members * num_unique_entities)), 
                         "assigning variable entity_discrete_marginal_prob_csr_row_pos");
             }
             {
-            current_statement_begin__ = 969;
+            current_statement_begin__ = 970;
             int latent_type_marginal_members_pos(0);
             (void) latent_type_marginal_members_pos;  // dummy to suppress unused var warning
             stan::math::fill(latent_type_marginal_members_pos, std::numeric_limits<int>::min());
             stan::math::assign(latent_type_marginal_members_pos,1);
-            current_statement_begin__ = 970;
+            current_statement_begin__ = 971;
             int entity_marginal_prob_pos(0);
             (void) entity_marginal_prob_pos;  // dummy to suppress unused var warning
             stan::math::fill(entity_marginal_prob_pos, std::numeric_limits<int>::min());
             stan::math::assign(entity_marginal_prob_pos,1);
-            current_statement_begin__ = 971;
+            current_statement_begin__ = 972;
             int entity_marginal_prob_csr_row_pos_pos(0);
             (void) entity_marginal_prob_csr_row_pos_pos;  // dummy to suppress unused var warning
             stan::math::fill(entity_marginal_prob_csr_row_pos_pos, std::numeric_limits<int>::min());
             stan::math::assign(entity_marginal_prob_csr_row_pos_pos,1);
-            current_statement_begin__ = 972;
+            current_statement_begin__ = 973;
             int last_entity_marginal_prob_size(0);
             (void) last_entity_marginal_prob_size;  // dummy to suppress unused var warning
             stan::math::fill(last_entity_marginal_prob_size, std::numeric_limits<int>::min());
-            current_statement_begin__ = 974;
+            current_statement_begin__ = 975;
             for (int latent_type_index = 1; latent_type_index <= total_num_discrete_bg_variable_types; ++latent_type_index) {
                 {
-                current_statement_begin__ = 975;
+                current_statement_begin__ = 976;
                 int curr_var_size(0);
                 (void) curr_var_size;  // dummy to suppress unused var warning
                 stan::math::fill(curr_var_size, std::numeric_limits<int>::min());
                 stan::math::assign(curr_var_size,get_base1(num_discrete_bg_variable_type_combo_members, latent_type_index, "num_discrete_bg_variable_type_combo_members", 1));
-                current_statement_begin__ = 976;
+                current_statement_begin__ = 977;
                 int latent_type_marginal_members_end(0);
                 (void) latent_type_marginal_members_end;  // dummy to suppress unused var warning
                 stan::math::fill(latent_type_marginal_members_end, std::numeric_limits<int>::min());
                 stan::math::assign(latent_type_marginal_members_end,((latent_type_marginal_members_pos + curr_var_size) - 1));
-                current_statement_begin__ = 978;
+                current_statement_begin__ = 979;
                 stan::model::assign(entity_single_discrete_marginal_prob_csr_row_pos, 
                             stan::model::cons_list(stan::model::index_uni(entity_marginal_prob_csr_row_pos_pos), stan::model::nil_index_list()), 
                             (logical_gt(entity_marginal_prob_csr_row_pos_pos, 1) ? (get_base1(entity_single_discrete_marginal_prob_csr_row_pos, (entity_marginal_prob_csr_row_pos_pos - 1), "entity_single_discrete_marginal_prob_csr_row_pos", 1) + last_entity_marginal_prob_size) : 1 ), 
                             "assigning variable entity_single_discrete_marginal_prob_csr_row_pos");
-                current_statement_begin__ = 982;
+                current_statement_begin__ = 983;
                 stan::math::assign(last_entity_marginal_prob_size, (curr_var_size * num_unique_entities));
-                current_statement_begin__ = 984;
+                current_statement_begin__ = 985;
                 for (int entity_index = 1; entity_index <= num_unique_entities; ++entity_index) {
                     {
-                    current_statement_begin__ = 985;
+                    current_statement_begin__ = 986;
                     local_scalar_t__ entity_prop(DUMMY_VAR__);
                     (void) entity_prop;  // dummy to suppress unused var warning
                     stan::math::initialize(entity_prop, DUMMY_VAR__);
                     stan::math::fill(entity_prop, DUMMY_VAR__);
                     stan::math::assign(entity_prop,(get_base1(num_obs_in_unique_entity, entity_index, "num_obs_in_unique_entity", 1) / std::max(num_obs, 1)));
-                    current_statement_begin__ = 986;
+                    current_statement_begin__ = 987;
                     int entity_marginal_prob_end(0);
                     (void) entity_marginal_prob_end;  // dummy to suppress unused var warning
                     stan::math::fill(entity_marginal_prob_end, std::numeric_limits<int>::min());
                     stan::math::assign(entity_marginal_prob_end,((entity_marginal_prob_pos + curr_var_size) - 1));
-                    current_statement_begin__ = 988;
+                    current_statement_begin__ = 989;
                     stan::model::assign(single_discrete_marginal_prob_csr_vec, 
                                 stan::model::cons_list(stan::model::index_min_max(entity_marginal_prob_pos, entity_marginal_prob_end), stan::model::nil_index_list()), 
                                 rep_vector(entity_prop, curr_var_size), 
                                 "assigning variable single_discrete_marginal_prob_csr_vec");
-                    current_statement_begin__ = 990;
+                    current_statement_begin__ = 991;
                     stan::model::assign(entity_single_discrete_marginal_prob_ids, 
                                 stan::model::cons_list(stan::model::index_min_max(entity_marginal_prob_pos, entity_marginal_prob_end), stan::model::nil_index_list()), 
                                 array_add(stan::model::rvalue(discrete_bg_variable_type_combo_members, stan::model::cons_list(stan::model::index_min_max(latent_type_marginal_members_pos, latent_type_marginal_members_end), stan::model::nil_index_list()), "discrete_bg_variable_type_combo_members"), static_cast<std::vector<int> >(stan::math::array_builder<int >().add(((entity_index - 1) * num_r_types)).array()), pstream__), 
                                 "assigning variable entity_single_discrete_marginal_prob_ids");
-                    current_statement_begin__ = 993;
+                    current_statement_begin__ = 994;
                     stan::math::assign(entity_marginal_prob_pos, (entity_marginal_prob_end + 1));
                     }
                 }
-                current_statement_begin__ = 996;
-                stan::math::assign(latent_type_marginal_members_pos, (latent_type_marginal_members_end + 1));
                 current_statement_begin__ = 997;
+                stan::math::assign(latent_type_marginal_members_pos, (latent_type_marginal_members_end + 1));
+                current_statement_begin__ = 998;
                 stan::math::assign(entity_marginal_prob_csr_row_pos_pos, (entity_marginal_prob_csr_row_pos_pos + 1));
                 }
             }
-            current_statement_begin__ = 1000;
+            current_statement_begin__ = 1001;
             stan::model::assign(entity_single_discrete_marginal_prob_csr_row_pos, 
                         stan::model::cons_list(stan::model::index_uni(entity_marginal_prob_csr_row_pos_pos), stan::model::nil_index_list()), 
                         (get_base1(entity_single_discrete_marginal_prob_csr_row_pos, (entity_marginal_prob_csr_row_pos_pos - 1), "entity_single_discrete_marginal_prob_csr_row_pos", 1) + last_entity_marginal_prob_size), 
                         "assigning variable entity_single_discrete_marginal_prob_csr_row_pos");
             }
-            current_statement_begin__ = 1004;
+            current_statement_begin__ = 1005;
             if (as_bool(logical_gt(total_num_discretized_bg_variable_types, 0))) {
                 {
-                current_statement_begin__ = 1005;
+                current_statement_begin__ = 1006;
                 int latent_type_marginal_members_pos(0);
                 (void) latent_type_marginal_members_pos;  // dummy to suppress unused var warning
                 stan::math::fill(latent_type_marginal_members_pos, std::numeric_limits<int>::min());
                 stan::math::assign(latent_type_marginal_members_pos,1);
-                current_statement_begin__ = 1006;
+                current_statement_begin__ = 1007;
                 int entity_marginal_prob_pos(0);
                 (void) entity_marginal_prob_pos;  // dummy to suppress unused var warning
                 stan::math::fill(entity_marginal_prob_pos, std::numeric_limits<int>::min());
                 stan::math::assign(entity_marginal_prob_pos,1);
-                current_statement_begin__ = 1007;
+                current_statement_begin__ = 1008;
                 int entity_marginal_prob_csr_row_pos_pos(0);
                 (void) entity_marginal_prob_csr_row_pos_pos;  // dummy to suppress unused var warning
                 stan::math::fill(entity_marginal_prob_csr_row_pos_pos, std::numeric_limits<int>::min());
                 stan::math::assign(entity_marginal_prob_csr_row_pos_pos,1);
-                current_statement_begin__ = 1008;
+                current_statement_begin__ = 1009;
                 int last_entity_marginal_prob_size(0);
                 (void) last_entity_marginal_prob_size;  // dummy to suppress unused var warning
                 stan::math::fill(last_entity_marginal_prob_size, std::numeric_limits<int>::min());
-                current_statement_begin__ = 1010;
+                current_statement_begin__ = 1011;
                 for (int latent_type_index = 1; latent_type_index <= total_num_discretized_bg_variable_types; ++latent_type_index) {
                     {
-                    current_statement_begin__ = 1011;
+                    current_statement_begin__ = 1012;
                     int curr_var_size(0);
                     (void) curr_var_size;  // dummy to suppress unused var warning
                     stan::math::fill(curr_var_size, std::numeric_limits<int>::min());
                     stan::math::assign(curr_var_size,get_base1(num_discretized_bg_variable_type_combo_members, latent_type_index, "num_discretized_bg_variable_type_combo_members", 1));
-                    current_statement_begin__ = 1012;
+                    current_statement_begin__ = 1013;
                     int latent_type_marginal_members_end(0);
                     (void) latent_type_marginal_members_end;  // dummy to suppress unused var warning
                     stan::math::fill(latent_type_marginal_members_end, std::numeric_limits<int>::min());
                     stan::math::assign(latent_type_marginal_members_end,((latent_type_marginal_members_pos + curr_var_size) - 1));
-                    current_statement_begin__ = 1014;
+                    current_statement_begin__ = 1015;
                     stan::model::assign(entity_discretized_marginal_prob_csr_row_pos, 
                                 stan::model::cons_list(stan::model::index_uni(entity_marginal_prob_csr_row_pos_pos), stan::model::nil_index_list()), 
                                 (logical_gt(entity_marginal_prob_csr_row_pos_pos, 1) ? (get_base1(entity_discretized_marginal_prob_csr_row_pos, (entity_marginal_prob_csr_row_pos_pos - 1), "entity_discretized_marginal_prob_csr_row_pos", 1) + last_entity_marginal_prob_size) : 1 ), 
                                 "assigning variable entity_discretized_marginal_prob_csr_row_pos");
-                    current_statement_begin__ = 1018;
+                    current_statement_begin__ = 1019;
                     stan::math::assign(last_entity_marginal_prob_size, (curr_var_size * num_unique_entities));
-                    current_statement_begin__ = 1020;
+                    current_statement_begin__ = 1021;
                     for (int entity_index = 1; entity_index <= num_unique_entities; ++entity_index) {
                         {
-                        current_statement_begin__ = 1021;
+                        current_statement_begin__ = 1022;
                         local_scalar_t__ entity_prop(DUMMY_VAR__);
                         (void) entity_prop;  // dummy to suppress unused var warning
                         stan::math::initialize(entity_prop, DUMMY_VAR__);
                         stan::math::fill(entity_prop, DUMMY_VAR__);
                         stan::math::assign(entity_prop,(get_base1(num_obs_in_unique_entity, entity_index, "num_obs_in_unique_entity", 1) / std::max(num_obs, 1)));
-                        current_statement_begin__ = 1022;
+                        current_statement_begin__ = 1023;
                         int entity_marginal_prob_end(0);
                         (void) entity_marginal_prob_end;  // dummy to suppress unused var warning
                         stan::math::fill(entity_marginal_prob_end, std::numeric_limits<int>::min());
                         stan::math::assign(entity_marginal_prob_end,((entity_marginal_prob_pos + curr_var_size) - 1));
-                        current_statement_begin__ = 1024;
+                        current_statement_begin__ = 1025;
                         stan::model::assign(discretized_marginal_prob_csr_vec, 
                                     stan::model::cons_list(stan::model::index_min_max(entity_marginal_prob_pos, entity_marginal_prob_end), stan::model::nil_index_list()), 
                                     rep_vector(entity_prop, curr_var_size), 
                                     "assigning variable discretized_marginal_prob_csr_vec");
-                        current_statement_begin__ = 1026;
+                        current_statement_begin__ = 1027;
                         stan::model::assign(entity_discretized_marginal_prob_ids, 
                                     stan::model::cons_list(stan::model::index_min_max(entity_marginal_prob_pos, entity_marginal_prob_end), stan::model::nil_index_list()), 
                                     array_add(stan::model::rvalue(discretized_bg_variable_type_combo_members, stan::model::cons_list(stan::model::index_min_max(latent_type_marginal_members_pos, latent_type_marginal_members_end), stan::model::nil_index_list()), "discretized_bg_variable_type_combo_members"), static_cast<std::vector<int> >(stan::math::array_builder<int >().add(((entity_index - 1) * num_r_types)).array()), pstream__), 
                                     "assigning variable entity_discretized_marginal_prob_ids");
-                        current_statement_begin__ = 1029;
+                        current_statement_begin__ = 1030;
                         stan::math::assign(entity_marginal_prob_pos, (entity_marginal_prob_end + 1));
                         }
                     }
-                    current_statement_begin__ = 1032;
-                    stan::math::assign(latent_type_marginal_members_pos, (latent_type_marginal_members_end + 1));
                     current_statement_begin__ = 1033;
+                    stan::math::assign(latent_type_marginal_members_pos, (latent_type_marginal_members_end + 1));
+                    current_statement_begin__ = 1034;
                     stan::math::assign(entity_marginal_prob_csr_row_pos_pos, (entity_marginal_prob_csr_row_pos_pos + 1));
                     }
                 }
-                current_statement_begin__ = 1036;
+                current_statement_begin__ = 1037;
                 stan::model::assign(entity_discretized_marginal_prob_csr_row_pos, 
                             stan::model::cons_list(stan::model::index_uni(entity_marginal_prob_csr_row_pos_pos), stan::model::nil_index_list()), 
                             (get_base1(entity_discretized_marginal_prob_csr_row_pos, (entity_marginal_prob_csr_row_pos_pos - 1), "entity_discretized_marginal_prob_csr_row_pos", 1) + last_entity_marginal_prob_size), 
                             "assigning variable entity_discretized_marginal_prob_csr_row_pos");
                 }
             }
-            current_statement_begin__ = 1040;
+            current_statement_begin__ = 1041;
             if (as_bool(logical_gt(num_estimand_levels, 0))) {
                 {
-                current_statement_begin__ = 1041;
+                current_statement_begin__ = 1042;
                 int estimand_entity_pos(0);
                 (void) estimand_entity_pos;  // dummy to suppress unused var warning
                 stan::math::fill(estimand_entity_pos, std::numeric_limits<int>::min());
                 stan::math::assign(estimand_entity_pos,1);
-                current_statement_begin__ = 1042;
+                current_statement_begin__ = 1043;
                 int level_estimands_csr_vec_pos(0);
                 (void) level_estimands_csr_vec_pos;  // dummy to suppress unused var warning
                 stan::math::fill(level_estimands_csr_vec_pos, std::numeric_limits<int>::min());
                 stan::math::assign(level_estimands_csr_vec_pos,1);
-                current_statement_begin__ = 1043;
+                current_statement_begin__ = 1044;
                 int entity_estimand_csr_row_pos_pos(0);
                 (void) entity_estimand_csr_row_pos_pos;  // dummy to suppress unused var warning
                 stan::math::fill(entity_estimand_csr_row_pos_pos, std::numeric_limits<int>::min());
                 stan::math::assign(entity_estimand_csr_row_pos_pos,1);
-                current_statement_begin__ = 1044;
+                current_statement_begin__ = 1045;
                 int last_num_unique_entities(0);
                 (void) last_num_unique_entities;  // dummy to suppress unused var warning
                 stan::math::fill(last_num_unique_entities, std::numeric_limits<int>::min());
-                current_statement_begin__ = 1046;
+                current_statement_begin__ = 1047;
                 for (int estimand_level_index = 1; estimand_level_index <= num_estimand_levels; ++estimand_level_index) {
                     {
-                    current_statement_begin__ = 1047;
+                    current_statement_begin__ = 1048;
                     int curr_estimand_level(0);
                     (void) curr_estimand_level;  // dummy to suppress unused var warning
                     stan::math::fill(curr_estimand_level, std::numeric_limits<int>::min());
                     stan::math::assign(curr_estimand_level,get_base1(estimand_levels, estimand_level_index, "estimand_levels", 1));
-                    current_statement_begin__ = 1048;
+                    current_statement_begin__ = 1049;
                     int curr_estimand_level_size(0);
                     (void) curr_estimand_level_size;  // dummy to suppress unused var warning
                     stan::math::fill(curr_estimand_level_size, std::numeric_limits<int>::min());
                     stan::math::assign(curr_estimand_level_size,get_base1(level_size, curr_estimand_level, "level_size", 1));
-                    current_statement_begin__ = 1049;
+                    current_statement_begin__ = 1050;
                     validate_non_negative_index("curr_num_unique_entities", "curr_estimand_level_size", curr_estimand_level_size);
                     std::vector<int  > curr_num_unique_entities(curr_estimand_level_size, int(0));
                     stan::math::fill(curr_num_unique_entities, std::numeric_limits<int>::min());
                     stan::math::assign(curr_num_unique_entities,array_extract_group_values(num_unique_entities_in_estimand_level_entities, stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list()), "level_size"), static_cast<std::vector<int> >(stan::math::array_builder<int >().add(estimand_level_index).array()), pstream__));
-                    current_statement_begin__ = 1051;
+                    current_statement_begin__ = 1052;
                     for (int estimand_level_entity_index = 1; estimand_level_entity_index <= curr_estimand_level_size; ++estimand_level_entity_index) {
                         {
-                        current_statement_begin__ = 1052;
+                        current_statement_begin__ = 1053;
                         validate_non_negative_index("unique_entities_in_curr_level_entity", "get_base1(curr_num_unique_entities, estimand_level_entity_index, \"curr_num_unique_entities\", 1)", get_base1(curr_num_unique_entities, estimand_level_entity_index, "curr_num_unique_entities", 1));
                         std::vector<int  > unique_entities_in_curr_level_entity(get_base1(curr_num_unique_entities, estimand_level_entity_index, "curr_num_unique_entities", 1), int(0));
                         stan::math::fill(unique_entities_in_curr_level_entity, std::numeric_limits<int>::min());
                         stan::math::assign(unique_entities_in_curr_level_entity,array_extract_group_values(stan::model::rvalue(unique_entities_in_level_entities, stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(curr_estimand_level), stan::model::nil_index_list())), "unique_entities_in_level_entities"), curr_num_unique_entities, static_cast<std::vector<int> >(stan::math::array_builder<int >().add(estimand_level_entity_index).array()), pstream__));
-                        current_statement_begin__ = 1055;
+                        current_statement_begin__ = 1056;
                         validate_non_negative_index("unique_entities_estimand_offset", "get_base1(curr_num_unique_entities, estimand_level_entity_index, \"curr_num_unique_entities\", 1)", get_base1(curr_num_unique_entities, estimand_level_entity_index, "curr_num_unique_entities", 1));
                         std::vector<int  > unique_entities_estimand_offset(get_base1(curr_num_unique_entities, estimand_level_entity_index, "curr_num_unique_entities", 1), int(0));
                         stan::math::fill(unique_entities_estimand_offset, std::numeric_limits<int>::min());
                         stan::math::assign(unique_entities_estimand_offset,array_product(array_add(unique_entities_in_curr_level_entity, static_cast<std::vector<int> >(stan::math::array_builder<int >().add(-(1)).array()), pstream__), static_cast<std::vector<int> >(stan::math::array_builder<int >().add(num_all_estimands).array()), pstream__));
-                        current_statement_begin__ = 1058;
+                        current_statement_begin__ = 1059;
                         validate_non_negative_index("curr_num_obs_in_unique_entity", "get_base1(curr_num_unique_entities, estimand_level_entity_index, \"curr_num_unique_entities\", 1)", get_base1(curr_num_unique_entities, estimand_level_entity_index, "curr_num_unique_entities", 1));
                         Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> curr_num_obs_in_unique_entity(get_base1(curr_num_unique_entities, estimand_level_entity_index, "curr_num_unique_entities", 1));
                         stan::math::initialize(curr_num_obs_in_unique_entity, DUMMY_VAR__);
                         stan::math::fill(curr_num_obs_in_unique_entity, DUMMY_VAR__);
                         stan::math::assign(curr_num_obs_in_unique_entity,stan::model::rvalue(num_obs_in_unique_entity, stan::model::cons_list(stan::model::index_multi(unique_entities_in_curr_level_entity), stan::model::nil_index_list()), "num_obs_in_unique_entity"));
-                        current_statement_begin__ = 1060;
+                        current_statement_begin__ = 1061;
                         for (int estimand_index = 1; estimand_index <= num_all_estimands; ++estimand_index) {
                             {
-                            current_statement_begin__ = 1061;
+                            current_statement_begin__ = 1062;
                             int level_estimands_csr_vec_end(0);
                             (void) level_estimands_csr_vec_end;  // dummy to suppress unused var warning
                             stan::math::fill(level_estimands_csr_vec_end, std::numeric_limits<int>::min());
                             stan::math::assign(level_estimands_csr_vec_end,((level_estimands_csr_vec_pos + get_base1(curr_num_unique_entities, estimand_level_entity_index, "curr_num_unique_entities", 1)) - 1));
-                            current_statement_begin__ = 1063;
+                            current_statement_begin__ = 1064;
                             stan::model::assign(entity_estimand_ids, 
                                         stan::model::cons_list(stan::model::index_min_max(level_estimands_csr_vec_pos, level_estimands_csr_vec_end), stan::model::nil_index_list()), 
                                         array_add(unique_entities_estimand_offset, static_cast<std::vector<int> >(stan::math::array_builder<int >().add(estimand_index).array()), pstream__), 
                                         "assigning variable entity_estimand_ids");
-                            current_statement_begin__ = 1064;
+                            current_statement_begin__ = 1065;
                             stan::model::assign(level_estimands_csr_vec, 
                                         stan::model::cons_list(stan::model::index_min_max(level_estimands_csr_vec_pos, level_estimands_csr_vec_end), stan::model::nil_index_list()), 
                                         divide(curr_num_obs_in_unique_entity, sum(curr_num_obs_in_unique_entity)), 
                                         "assigning variable level_estimands_csr_vec");
-                            current_statement_begin__ = 1066;
+                            current_statement_begin__ = 1067;
                             stan::model::assign(entity_estimand_csr_row_pos, 
                                         stan::model::cons_list(stan::model::index_uni(entity_estimand_csr_row_pos_pos), stan::model::nil_index_list()), 
                                         (logical_gt(entity_estimand_csr_row_pos_pos, 1) ? (get_base1(entity_estimand_csr_row_pos, (entity_estimand_csr_row_pos_pos - 1), "entity_estimand_csr_row_pos", 1) + last_num_unique_entities) : 1 ), 
                                         "assigning variable entity_estimand_csr_row_pos");
-                            current_statement_begin__ = 1070;
+                            current_statement_begin__ = 1071;
                             stan::math::assign(last_num_unique_entities, get_base1(curr_num_unique_entities, estimand_level_entity_index, "curr_num_unique_entities", 1));
-                            current_statement_begin__ = 1072;
-                            stan::math::assign(entity_estimand_csr_row_pos_pos, (entity_estimand_csr_row_pos_pos + 1));
                             current_statement_begin__ = 1073;
+                            stan::math::assign(entity_estimand_csr_row_pos_pos, (entity_estimand_csr_row_pos_pos + 1));
+                            current_statement_begin__ = 1074;
                             stan::math::assign(level_estimands_csr_vec_pos, (level_estimands_csr_vec_end + 1));
                             }
                         }
-                        current_statement_begin__ = 1076;
+                        current_statement_begin__ = 1077;
                         stan::math::assign(estimand_entity_pos, (estimand_entity_pos + 1));
                         }
                     }
                     }
                 }
-                current_statement_begin__ = 1080;
+                current_statement_begin__ = 1081;
                 stan::model::assign(entity_estimand_csr_row_pos, 
                             stan::model::cons_list(stan::model::index_uni(entity_estimand_csr_row_pos_pos), stan::model::nil_index_list()), 
                             (get_base1(entity_estimand_csr_row_pos, (entity_estimand_csr_row_pos_pos - 1), "entity_estimand_csr_row_pos", 1) + last_num_unique_entities), 
                             "assigning variable entity_estimand_csr_row_pos");
                 }
             }
-            current_statement_begin__ = 1083;
+            current_statement_begin__ = 1084;
             if (as_bool(logical_gt(num_discretized_groups, 0))) {
                 {
-                current_statement_begin__ = 1084;
+                current_statement_begin__ = 1085;
                 int discretized_group_pos(0);
                 (void) discretized_group_pos;  // dummy to suppress unused var warning
                 stan::math::fill(discretized_group_pos, std::numeric_limits<int>::min());
                 stan::math::assign(discretized_group_pos,1);
-                current_statement_begin__ = 1085;
+                current_statement_begin__ = 1086;
                 int histogram_vec_pos(0);
                 (void) histogram_vec_pos;  // dummy to suppress unused var warning
                 stan::math::fill(histogram_vec_pos, std::numeric_limits<int>::min());
                 stan::math::assign(histogram_vec_pos,1);
-                current_statement_begin__ = 1086;
+                current_statement_begin__ = 1087;
                 int histogram_ids_pos(0);
                 (void) histogram_ids_pos;  // dummy to suppress unused var warning
                 stan::math::fill(histogram_ids_pos, std::numeric_limits<int>::min());
                 stan::math::assign(histogram_ids_pos,1);
-                current_statement_begin__ = 1088;
+                current_statement_begin__ = 1089;
                 int midpoint_vec_pos(0);
                 (void) midpoint_vec_pos;  // dummy to suppress unused var warning
                 stan::math::fill(midpoint_vec_pos, std::numeric_limits<int>::min());
                 stan::math::assign(midpoint_vec_pos,1);
-                current_statement_begin__ = 1089;
+                current_statement_begin__ = 1090;
                 int midpoint_ids_pos(0);
                 (void) midpoint_ids_pos;  // dummy to suppress unused var warning
                 stan::math::fill(midpoint_ids_pos, std::numeric_limits<int>::min());
                 stan::math::assign(midpoint_ids_pos,1);
-                current_statement_begin__ = 1091;
+                current_statement_begin__ = 1092;
                 int histogram_ids_size(0);
                 (void) histogram_ids_size;  // dummy to suppress unused var warning
                 stan::math::fill(histogram_ids_size, std::numeric_limits<int>::min());
                 stan::math::assign(histogram_ids_size,(num_discretized_groups * ((2 * num_discretized_variables) + 1)));
-                current_statement_begin__ = 1092;
+                current_statement_begin__ = 1093;
                 validate_non_negative_index("histogram_last_id_pos", "num_discretized_groups", num_discretized_groups);
                 std::vector<int  > histogram_last_id_pos(num_discretized_groups, int(0));
                 stan::math::fill(histogram_last_id_pos, std::numeric_limits<int>::min());
-                current_statement_begin__ = 1093;
+                current_statement_begin__ = 1094;
                 int last_histogram_one_pos(0);
                 (void) last_histogram_one_pos;  // dummy to suppress unused var warning
                 stan::math::fill(last_histogram_one_pos, std::numeric_limits<int>::min());
                 stan::math::assign(last_histogram_one_pos,((num_unique_entities * num_atom_estimands) + 1));
-                current_statement_begin__ = 1095;
+                current_statement_begin__ = 1096;
                 validate_non_negative_index("histogram_ids", "histogram_ids_size", histogram_ids_size);
                 std::vector<int  > histogram_ids(histogram_ids_size, int(0));
                 stan::math::fill(histogram_ids, std::numeric_limits<int>::min());
-                current_statement_begin__ = 1097;
+                current_statement_begin__ = 1098;
                 validate_non_negative_index("midpoint_ids", "(num_discretized_groups * (num_cutpoints - 1))", (num_discretized_groups * (num_cutpoints - 1)));
                 std::vector<int  > midpoint_ids((num_discretized_groups * (num_cutpoints - 1)), int(0));
                 stan::math::fill(midpoint_ids, std::numeric_limits<int>::min());
-                current_statement_begin__ = 1100;
+                current_statement_begin__ = 1101;
                 validate_non_negative_index("histogram_row_sizes", "((num_cutpoints - 1) * num_discretized_groups)", ((num_cutpoints - 1) * num_discretized_groups));
                 std::vector<int  > histogram_row_sizes(((num_cutpoints - 1) * num_discretized_groups), int(0));
                 stan::math::fill(histogram_row_sizes, std::numeric_limits<int>::min());
                 stan::math::assign(histogram_row_sizes,to_array_1d(rep_array(append_array(static_cast<std::vector<int> >(stan::math::array_builder<int >().add(1).array()), rep_array(2, num_discretized_variables)), num_discretized_groups)));
-                current_statement_begin__ = 1102;
-                stan::math::assign(entity_histogram_csr_row_pos, csr_shift_expand_u(histogram_row_sizes, num_unique_entities, pstream__));
                 current_statement_begin__ = 1103;
+                stan::math::assign(entity_histogram_csr_row_pos, csr_shift_expand_u(histogram_row_sizes, num_unique_entities, pstream__));
+                current_statement_begin__ = 1104;
                 stan::math::assign(entity_midpoint_csr_row_pos, csr_shift_expand_u(rep_array((num_cutpoints - 1), num_discretized_groups), num_unique_entities, pstream__));
-                current_statement_begin__ = 1105;
+                current_statement_begin__ = 1106;
                 for (int discretized_group_index = 1; discretized_group_index <= num_discretized_groups; ++discretized_group_index) {
                     {
-                    current_statement_begin__ = 1106;
+                    current_statement_begin__ = 1107;
                     int histogram_ids_end(0);
                     (void) histogram_ids_end;  // dummy to suppress unused var warning
                     stan::math::fill(histogram_ids_end, std::numeric_limits<int>::min());
                     stan::math::assign(histogram_ids_end,((histogram_ids_pos + ((2 * num_discretized_variables) + 1)) - 1));
-                    current_statement_begin__ = 1107;
+                    current_statement_begin__ = 1108;
                     int discretized_group_end(0);
                     (void) discretized_group_end;  // dummy to suppress unused var warning
                     stan::math::fill(discretized_group_end, std::numeric_limits<int>::min());
                     stan::math::assign(discretized_group_end,((discretized_group_pos + num_discretized_variables) - 1));
-                    current_statement_begin__ = 1108;
+                    current_statement_begin__ = 1109;
                     int midpoint_ids_end(0);
                     (void) midpoint_ids_end;  // dummy to suppress unused var warning
                     stan::math::fill(midpoint_ids_end, std::numeric_limits<int>::min());
                     stan::math::assign(midpoint_ids_end,((midpoint_ids_pos + (num_cutpoints - 1)) - 1));
-                    current_statement_begin__ = 1110;
+                    current_statement_begin__ = 1111;
                     validate_non_negative_index("curr_group_members", "num_discretized_variables", num_discretized_variables);
                     std::vector<int  > curr_group_members(num_discretized_variables, int(0));
                     stan::math::fill(curr_group_members, std::numeric_limits<int>::min());
                     stan::math::assign(curr_group_members,stan::model::rvalue(discretized_group_ids, stan::model::cons_list(stan::model::index_min_max(discretized_group_pos, discretized_group_end), stan::model::nil_index_list()), "discretized_group_ids"));
-                    current_statement_begin__ = 1112;
+                    current_statement_begin__ = 1113;
                     stan::model::assign(histogram_last_id_pos, 
                                 stan::model::cons_list(stan::model::index_uni(discretized_group_index), stan::model::nil_index_list()), 
                                 histogram_ids_end, 
                                 "assigning variable histogram_last_id_pos");
-                    current_statement_begin__ = 1114;
+                    current_statement_begin__ = 1115;
                     for (int entity_index = 1; entity_index <= num_unique_entities; ++entity_index) {
                         {
-                        current_statement_begin__ = 1115;
+                        current_statement_begin__ = 1116;
                         int histogram_vec_end(0);
                         (void) histogram_vec_end;  // dummy to suppress unused var warning
                         stan::math::fill(histogram_vec_end, std::numeric_limits<int>::min());
                         stan::math::assign(histogram_vec_end,((histogram_vec_pos + ((2 * num_discretized_variables) + 1)) - 1));
-                        current_statement_begin__ = 1116;
+                        current_statement_begin__ = 1117;
                         int midpoint_vec_end(0);
                         (void) midpoint_vec_end;  // dummy to suppress unused var warning
                         stan::math::fill(midpoint_vec_end, std::numeric_limits<int>::min());
                         stan::math::assign(midpoint_vec_end,((midpoint_vec_pos + (num_cutpoints - 1)) - 1));
-                        current_statement_begin__ = 1118;
+                        current_statement_begin__ = 1119;
                         stan::model::assign(entity_histogram_vec, 
                                     stan::model::cons_list(stan::model::index_min_max(histogram_vec_pos, histogram_vec_end), stan::model::nil_index_list()), 
                                     append_row(to_vector(rep_matrix(transpose(stan::math::to_row_vector(stan::math::array_builder<double >().add(1).add(-(1)).array())), num_discretized_variables)), 1), 
                                     "assigning variable entity_histogram_vec");
-                        current_statement_begin__ = 1119;
+                        current_statement_begin__ = 1120;
                         stan::model::assign(entity_midpoint_vec, 
                                     stan::model::cons_list(stan::model::index_min_max(midpoint_vec_pos, midpoint_vec_end), stan::model::nil_index_list()), 
                                     cutpoint_midpoints, 
                                     "assigning variable entity_midpoint_vec");
-                        current_statement_begin__ = 1121;
+                        current_statement_begin__ = 1122;
                         if (as_bool(logical_gt(num_discrete_utility_values, 0))) {
-                            current_statement_begin__ = 1122;
+                            current_statement_begin__ = 1123;
                             stan::model::assign(entity_utility_vec, 
                                         stan::model::cons_list(stan::model::index_min_max(midpoint_vec_pos, midpoint_vec_end), stan::model::nil_index_list()), 
                                         utility, 
                                         "assigning variable entity_utility_vec");
                         }
-                        current_statement_begin__ = 1125;
+                        current_statement_begin__ = 1126;
                         stan::model::assign(entity_discretize_bin_alpha, 
                                     stan::model::cons_list(stan::model::index_min_max(midpoint_vec_pos, midpoint_vec_end), stan::model::nil_index_list()), 
                                     discretize_bin_alpha, 
                                     "assigning variable entity_discretize_bin_alpha");
-                        current_statement_begin__ = 1126;
+                        current_statement_begin__ = 1127;
                         stan::model::assign(entity_discretize_bin_beta, 
                                     stan::model::cons_list(stan::model::index_min_max(midpoint_vec_pos, midpoint_vec_end), stan::model::nil_index_list()), 
                                     discretize_bin_beta, 
                                     "assigning variable entity_discretize_bin_beta");
-                        current_statement_begin__ = 1128;
-                        stan::math::assign(histogram_vec_pos, (histogram_vec_end + 1));
                         current_statement_begin__ = 1129;
+                        stan::math::assign(histogram_vec_pos, (histogram_vec_end + 1));
+                        current_statement_begin__ = 1130;
                         stan::math::assign(midpoint_vec_pos, (midpoint_vec_end + 1));
                         }
                     }
-                    current_statement_begin__ = 1132;
+                    current_statement_begin__ = 1133;
                     for (int group_member_index = 1; group_member_index <= num_discretized_variables; ++group_member_index) {
                         {
-                        current_statement_begin__ = 1133;
+                        current_statement_begin__ = 1134;
                         int offset(0);
                         (void) offset;  // dummy to suppress unused var warning
                         stan::math::fill(offset, std::numeric_limits<int>::min());
                         stan::math::assign(offset,(2 * (group_member_index - 1)));
-                        current_statement_begin__ = 1135;
+                        current_statement_begin__ = 1136;
                         stan::model::assign(histogram_ids, 
                                     stan::model::cons_list(stan::model::index_min_max((histogram_ids_pos + offset), ((histogram_ids_pos + offset) + 1)), stan::model::nil_index_list()), 
                                     rep_array(get_base1(curr_group_members, group_member_index, "curr_group_members", 1), 2), 
                                     "assigning variable histogram_ids");
                         }
                     }
-                    current_statement_begin__ = 1138;
+                    current_statement_begin__ = 1139;
                     stan::model::assign(histogram_ids, 
                                 stan::model::cons_list(stan::model::index_min_max((histogram_ids_end - 1), histogram_ids_end), stan::model::nil_index_list()), 
                                 static_cast<std::vector<int> >(stan::math::array_builder<int >().add(get_base1(curr_group_members, num_discretized_variables, "curr_group_members", 1)).add(0).array()), 
                                 "assigning variable histogram_ids");
-                    current_statement_begin__ = 1140;
+                    current_statement_begin__ = 1141;
                     stan::model::assign(midpoint_ids, 
                                 stan::model::cons_list(stan::model::index_min_max(midpoint_ids_pos, midpoint_ids_end), stan::model::nil_index_list()), 
                                 seq((1 + ((discretized_group_index - 1) * (num_cutpoints - 1))), (discretized_group_index * (num_cutpoints - 1)), 1, pstream__), 
                                 "assigning variable midpoint_ids");
-                    current_statement_begin__ = 1142;
-                    stan::math::assign(histogram_ids_pos, (histogram_ids_end + 1));
                     current_statement_begin__ = 1143;
-                    stan::math::assign(discretized_group_pos, (discretized_group_end + 1));
+                    stan::math::assign(histogram_ids_pos, (histogram_ids_end + 1));
                     current_statement_begin__ = 1144;
+                    stan::math::assign(discretized_group_pos, (discretized_group_end + 1));
+                    current_statement_begin__ = 1145;
                     stan::math::assign(midpoint_ids_pos, (midpoint_ids_end + 1));
                     }
                 }
-                current_statement_begin__ = 1147;
+                current_statement_begin__ = 1148;
                 stan::math::assign(entity_histogram_ids, csr_shift_expand_v(histogram_ids, num_atom_estimands, num_unique_entities, pstream__));
-                current_statement_begin__ = 1149;
+                current_statement_begin__ = 1150;
                 for (int entity_index = 1; entity_index <= num_unique_entities; ++entity_index) {
-                    current_statement_begin__ = 1150;
+                    current_statement_begin__ = 1151;
                     stan::model::assign(entity_histogram_ids, 
                                 stan::model::cons_list(stan::model::index_multi(array_add(histogram_last_id_pos, static_cast<std::vector<int> >(stan::math::array_builder<int >().add(((entity_index - 1) * histogram_ids_size)).array()), pstream__)), stan::model::nil_index_list()), 
                                 rep_array(last_histogram_one_pos, num_discretized_groups), 
                                 "assigning variable entity_histogram_ids");
                 }
-                current_statement_begin__ = 1153;
+                current_statement_begin__ = 1154;
                 stan::math::assign(entity_midpoint_ids, csr_shift_expand_v(midpoint_ids, (num_discretized_groups * (num_cutpoints - 1)), num_unique_entities, pstream__));
                 }
             }
-            current_statement_begin__ = 1156;
+            current_statement_begin__ = 1157;
             if (as_bool(logical_gt(num_between_entity_diff_levels, 0))) {
                 {
-                current_statement_begin__ = 1157;
+                current_statement_begin__ = 1158;
                 int between_csr_ids_pos(0);
                 (void) between_csr_ids_pos;  // dummy to suppress unused var warning
                 stan::math::fill(between_csr_ids_pos, std::numeric_limits<int>::min());
                 stan::math::assign(between_csr_ids_pos,1);
-                current_statement_begin__ = 1159;
+                current_statement_begin__ = 1160;
                 stan::math::assign(between_entity_diff_csr_row_pos, seq(1, (((2 * num_atom_estimands) * (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), "level_size")) - num_between_entity_diff_levels)) + 1), 2, pstream__));
-                current_statement_begin__ = 1161;
+                current_statement_begin__ = 1162;
                 for (int between_diff_level_index_index = 1; between_diff_level_index_index <= num_between_entity_diff_levels; ++between_diff_level_index_index) {
                     {
-                    current_statement_begin__ = 1162;
+                    current_statement_begin__ = 1163;
                     int between_diff_level_index(0);
                     (void) between_diff_level_index;  // dummy to suppress unused var warning
                     stan::math::fill(between_diff_level_index, std::numeric_limits<int>::min());
                     stan::math::assign(between_diff_level_index,get_base1(between_entity_diff_levels, between_diff_level_index_index, "between_entity_diff_levels", 1));
-                    current_statement_begin__ = 1163;
+                    current_statement_begin__ = 1164;
                     int between_diff_level_offset(0);
                     (void) between_diff_level_offset;  // dummy to suppress unused var warning
                     stan::math::fill(between_diff_level_offset, std::numeric_limits<int>::min());
                     stan::math::assign(between_diff_level_offset,(logical_gt(between_diff_level_index, 1) ? (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_max((between_diff_level_index - 1)), stan::model::nil_index_list()), "level_size")) * num_all_estimands) : 0 ));
-                    current_statement_begin__ = 1165;
+                    current_statement_begin__ = 1166;
                     for (int between_diff_entity_index = 1; between_diff_entity_index <= (get_base1(level_size, between_diff_level_index, "level_size", 1) - 1); ++between_diff_entity_index) {
                         {
-                        current_statement_begin__ = 1166;
+                        current_statement_begin__ = 1167;
                         validate_non_negative_index("diff_pair", "2", 2);
                         std::vector<int  > diff_pair(2, int(0));
                         stan::math::fill(diff_pair, std::numeric_limits<int>::min());
                         stan::math::assign(diff_pair,static_cast<std::vector<int> >(stan::math::array_builder<int >().add(between_diff_level_offset).add((between_diff_level_offset + (num_all_estimands * between_diff_entity_index))).array()));
-                        current_statement_begin__ = 1168;
+                        current_statement_begin__ = 1169;
                         for (int estimand_index = 1; estimand_index <= num_atom_estimands; ++estimand_index) {
-                            current_statement_begin__ = 1169;
+                            current_statement_begin__ = 1170;
                             stan::model::assign(between_entity_diff_csr_ids, 
                                         stan::model::cons_list(stan::model::index_min_max(between_csr_ids_pos, (between_csr_ids_pos + 1)), stan::model::nil_index_list()), 
                                         array_add(diff_pair, static_cast<std::vector<int> >(stan::math::array_builder<int >().add(estimand_index).array()), pstream__), 
                                         "assigning variable between_entity_diff_csr_ids");
-                            current_statement_begin__ = 1170;
+                            current_statement_begin__ = 1171;
                             stan::math::assign(between_csr_ids_pos, (between_csr_ids_pos + 2));
                         }
                         }
@@ -3966,70 +3977,70 @@ public:
                 }
             }
             {
-            current_statement_begin__ = 1177;
+            current_statement_begin__ = 1178;
             int exp_r_pos(0);
             (void) exp_r_pos;  // dummy to suppress unused var warning
             stan::math::fill(exp_r_pos, std::numeric_limits<int>::min());
             stan::math::assign(exp_r_pos,1);
-            current_statement_begin__ = 1179;
+            current_statement_begin__ = 1180;
             for (int r_type_index = 1; r_type_index <= num_r_types; ++r_type_index) {
                 {
-                current_statement_begin__ = 1180;
+                current_statement_begin__ = 1181;
                 int exp_r_end(0);
                 (void) exp_r_end;  // dummy to suppress unused var warning
                 stan::math::fill(exp_r_end, std::numeric_limits<int>::min());
                 stan::math::assign(exp_r_end,((exp_r_pos + num_experiment_types) - 1));
-                current_statement_begin__ = 1182;
+                current_statement_begin__ = 1183;
                 stan::model::assign(experiment_r_type_index, 
                             stan::model::cons_list(stan::model::index_min_max(exp_r_pos, exp_r_end), stan::model::nil_index_list()), 
                             rep_array(r_type_index, num_experiment_types), 
                             "assigning variable experiment_r_type_index");
-                current_statement_begin__ = 1184;
+                current_statement_begin__ = 1185;
                 stan::math::assign(exp_r_pos, (exp_r_end + 1));
                 }
             }
             }
             // validate transformed data
-            current_statement_begin__ = 694;
+            current_statement_begin__ = 695;
             size_t num_discretized_types_conditional_i_0_max__ = num_discrete_r_types;
             for (size_t i_0__ = 0; i_0__ < num_discretized_types_conditional_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "num_discretized_types_conditional[i_0__]", num_discretized_types_conditional[i_0__], 0);
                 check_less_or_equal(function__, "num_discretized_types_conditional[i_0__]", num_discretized_types_conditional[i_0__], num_discretized_r_types);
             }
-            current_statement_begin__ = 696;
+            current_statement_begin__ = 697;
             size_t discretized_types_conditional_i_0_max__ = sum(num_discretized_types_conditional);
             for (size_t i_0__ = 0; i_0__ < discretized_types_conditional_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "discretized_types_conditional[i_0__]", discretized_types_conditional[i_0__], 1);
                 check_less_or_equal(function__, "discretized_types_conditional[i_0__]", discretized_types_conditional[i_0__], num_discretized_r_types);
             }
-            current_statement_begin__ = 708;
-            check_greater_or_equal(function__, "num_r_types_full", num_r_types_full, num_r_types);
             current_statement_begin__ = 709;
+            check_greater_or_equal(function__, "num_r_types_full", num_r_types_full, num_r_types);
+            current_statement_begin__ = 710;
             size_t experiment_r_type_index_i_0_max__ = num_r_types_full;
             for (size_t i_0__ = 0; i_0__ < experiment_r_type_index_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "experiment_r_type_index[i_0__]", experiment_r_type_index[i_0__], 1);
                 check_less_or_equal(function__, "experiment_r_type_index[i_0__]", experiment_r_type_index[i_0__], num_r_types);
             }
-            current_statement_begin__ = 711;
+            current_statement_begin__ = 712;
             check_greater_or_equal(function__, "full_experiment_types_prob", full_experiment_types_prob, 0);
             check_less_or_equal(function__, "full_experiment_types_prob", full_experiment_types_prob, 1);
-            current_statement_begin__ = 713;
+            current_statement_begin__ = 714;
             size_t level_size_i_0_max__ = num_levels;
             for (size_t i_0__ = 0; i_0__ < level_size_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "level_size[i_0__]", level_size[i_0__], 1);
             }
-            current_statement_begin__ = 714;
+            current_statement_begin__ = 715;
             check_greater_or_equal(function__, "num_obs_in_unique_entity", num_obs_in_unique_entity, 0);
             check_less_or_equal(function__, "num_obs_in_unique_entity", num_obs_in_unique_entity, num_obs);
-            current_statement_begin__ = 715;
+            current_statement_begin__ = 716;
             stan::math::check_simplex(function__, "unique_entity_prop", unique_entity_prop);
-            current_statement_begin__ = 717;
+            current_statement_begin__ = 718;
             size_t num_unique_entities_in_estimand_level_entities_i_0_max__ = sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list()), "level_size"));
             for (size_t i_0__ = 0; i_0__ < num_unique_entities_in_estimand_level_entities_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "num_unique_entities_in_estimand_level_entities[i_0__]", num_unique_entities_in_estimand_level_entities[i_0__], 1);
                 check_less_or_equal(function__, "num_unique_entities_in_estimand_level_entities[i_0__]", num_unique_entities_in_estimand_level_entities[i_0__], num_unique_entities);
             }
-            current_statement_begin__ = 720;
+            current_statement_begin__ = 721;
             size_t unique_entities_in_level_entities_i_0_max__ = num_unique_entities;
             size_t unique_entities_in_level_entities_i_1_max__ = num_levels;
             for (size_t i_0__ = 0; i_0__ < unique_entities_in_level_entities_i_0_max__; ++i_0__) {
@@ -4038,206 +4049,206 @@ public:
                     check_less_or_equal(function__, "unique_entities_in_level_entities[i_0__][i_1__]", unique_entities_in_level_entities[i_0__][i_1__], num_unique_entities);
                 }
             }
-            current_statement_begin__ = 725;
+            current_statement_begin__ = 726;
             check_greater_or_equal(function__, "vec_diff", vec_diff, -(1));
             check_less_or_equal(function__, "vec_diff", vec_diff, 1);
-            current_statement_begin__ = 726;
+            current_statement_begin__ = 727;
             check_greater_or_equal(function__, "vec_mean_diff", vec_mean_diff, -(1));
             check_less_or_equal(function__, "vec_mean_diff", vec_mean_diff, 1);
-            current_statement_begin__ = 727;
+            current_statement_begin__ = 728;
             check_greater_or_equal(function__, "vec_utility_diff", vec_utility_diff, -(1));
             check_less_or_equal(function__, "vec_utility_diff", vec_utility_diff, 1);
-            current_statement_begin__ = 734;
+            current_statement_begin__ = 735;
             check_greater_or_equal(function__, "vec_1", vec_1, 1);
             check_less_or_equal(function__, "vec_1", vec_1, 1);
-            current_statement_begin__ = 736;
+            current_statement_begin__ = 737;
             size_t entity_total_num_candidates_i_0_max__ = (logical_gt(num_obs, 0) ? num_unique_entities : 0 );
             for (size_t i_0__ = 0; i_0__ < entity_total_num_candidates_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_total_num_candidates[i_0__]", entity_total_num_candidates[i_0__], 1);
             }
-            current_statement_begin__ = 745;
+            current_statement_begin__ = 746;
             size_t entity_candidate_group_ids_i_0_max__ = sum(entity_total_num_candidates);
             for (size_t i_0__ = 0; i_0__ < entity_candidate_group_ids_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_candidate_group_ids[i_0__]", entity_candidate_group_ids[i_0__], 1);
                 check_less_or_equal(function__, "entity_candidate_group_ids[i_0__]", entity_candidate_group_ids[i_0__], (num_r_types * num_unique_entities));
             }
-            current_statement_begin__ = 746;
+            current_statement_begin__ = 747;
             size_t entity_candidate_group_csr_row_pos_i_0_max__ = (sum(num_unique_entity_candidate_groups) + 1);
             for (size_t i_0__ = 0; i_0__ < entity_candidate_group_csr_row_pos_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_candidate_group_csr_row_pos[i_0__]", entity_candidate_group_csr_row_pos[i_0__], 1);
                 check_less_or_equal(function__, "entity_candidate_group_csr_row_pos[i_0__]", entity_candidate_group_csr_row_pos[i_0__], (sum(stan::model::rvalue(candidate_group_size, stan::model::cons_list(stan::model::index_multi(unique_entity_candidate_groups), stan::model::nil_index_list()), "candidate_group_size")) + 1));
             }
-            current_statement_begin__ = 748;
+            current_statement_begin__ = 749;
             size_t obs_candidate_group_ids_i_0_max__ = sum(stan::model::rvalue(candidate_group_size, stan::model::cons_list(stan::model::index_multi(obs_candidate_group), stan::model::nil_index_list()), "candidate_group_size"));
             for (size_t i_0__ = 0; i_0__ < obs_candidate_group_ids_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "obs_candidate_group_ids[i_0__]", obs_candidate_group_ids[i_0__], 1);
                 check_less_or_equal(function__, "obs_candidate_group_ids[i_0__]", obs_candidate_group_ids[i_0__], (num_r_types * num_unique_entities));
             }
-            current_statement_begin__ = 749;
+            current_statement_begin__ = 750;
             size_t obs_candidate_group_csr_row_pos_i_0_max__ = (num_obs + 1);
             for (size_t i_0__ = 0; i_0__ < obs_candidate_group_csr_row_pos_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "obs_candidate_group_csr_row_pos[i_0__]", obs_candidate_group_csr_row_pos[i_0__], 1);
                 check_less_or_equal(function__, "obs_candidate_group_csr_row_pos[i_0__]", obs_candidate_group_csr_row_pos[i_0__], (sum(stan::model::rvalue(candidate_group_size, stan::model::cons_list(stan::model::index_multi(obs_candidate_group), stan::model::nil_index_list()), "candidate_group_size")) + 1));
             }
-            current_statement_begin__ = 751;
+            current_statement_begin__ = 752;
             size_t entity_abducted_prob_ids_i_0_max__ = (sum(abducted_prob_size) * num_unique_entities);
             for (size_t i_0__ = 0; i_0__ < entity_abducted_prob_ids_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_abducted_prob_ids[i_0__]", entity_abducted_prob_ids[i_0__], 1);
                 check_less_or_equal(function__, "entity_abducted_prob_ids[i_0__]", entity_abducted_prob_ids[i_0__], (num_r_types_full * num_unique_entities));
             }
-            current_statement_begin__ = 752;
+            current_statement_begin__ = 753;
             size_t entity_abducted_prob_csr_row_pos_i_0_max__ = (num_abducted_estimands ? ((num_unique_entities * num_abducted_estimands) + 1) : 0 );
             for (size_t i_0__ = 0; i_0__ < entity_abducted_prob_csr_row_pos_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_abducted_prob_csr_row_pos[i_0__]", entity_abducted_prob_csr_row_pos[i_0__], 1);
             }
-            current_statement_begin__ = 754;
+            current_statement_begin__ = 755;
             size_t long_entity_abducted_index_i_0_max__ = (num_unique_entities * num_abducted_estimands);
             for (size_t i_0__ = 0; i_0__ < long_entity_abducted_index_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "long_entity_abducted_index[i_0__]", long_entity_abducted_index[i_0__], 1);
             }
-            current_statement_begin__ = 756;
+            current_statement_begin__ = 757;
             size_t entity_est_prob_ids_i_0_max__ = (sum(est_prob_size) * num_unique_entities);
             for (size_t i_0__ = 0; i_0__ < entity_est_prob_ids_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_est_prob_ids[i_0__]", entity_est_prob_ids[i_0__], 1);
                 check_less_or_equal(function__, "entity_est_prob_ids[i_0__]", entity_est_prob_ids[i_0__], (num_r_types_full * num_unique_entities));
             }
-            current_statement_begin__ = 757;
+            current_statement_begin__ = 758;
             size_t entity_est_prob_csr_row_pos_i_0_max__ = (logical_gt(num_atom_estimands, 0) ? ((num_unique_entities * num_atom_estimands) + 1) : 0 );
             for (size_t i_0__ = 0; i_0__ < entity_est_prob_csr_row_pos_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_est_prob_csr_row_pos[i_0__]", entity_est_prob_csr_row_pos[i_0__], 1);
             }
-            current_statement_begin__ = 759;
+            current_statement_begin__ = 760;
             size_t entity_diff_estimand_ids_i_0_max__ = ((num_diff_estimands * 2) * num_unique_entities);
             for (size_t i_0__ = 0; i_0__ < entity_diff_estimand_ids_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_diff_estimand_ids[i_0__]", entity_diff_estimand_ids[i_0__], 1);
                 check_less_or_equal(function__, "entity_diff_estimand_ids[i_0__]", entity_diff_estimand_ids[i_0__], (num_atom_estimands * num_unique_entities));
             }
-            current_statement_begin__ = 760;
+            current_statement_begin__ = 761;
             size_t entity_diff_estimand_csr_row_pos_i_0_max__ = (logical_gt(num_diff_estimands, 0) ? ((num_unique_entities * num_diff_estimands) + 1) : 0 );
             for (size_t i_0__ = 0; i_0__ < entity_diff_estimand_csr_row_pos_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_diff_estimand_csr_row_pos[i_0__]", entity_diff_estimand_csr_row_pos[i_0__], 1);
             }
-            current_statement_begin__ = 762;
+            current_statement_begin__ = 763;
             size_t entity_mean_diff_estimand_ids_i_0_max__ = ((num_mean_diff_estimands * 2) * num_unique_entities);
             for (size_t i_0__ = 0; i_0__ < entity_mean_diff_estimand_ids_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_mean_diff_estimand_ids[i_0__]", entity_mean_diff_estimand_ids[i_0__], 1);
                 check_less_or_equal(function__, "entity_mean_diff_estimand_ids[i_0__]", entity_mean_diff_estimand_ids[i_0__], (num_discretized_groups * num_unique_entities));
             }
-            current_statement_begin__ = 763;
+            current_statement_begin__ = 764;
             size_t entity_mean_diff_estimand_csr_row_pos_i_0_max__ = (logical_gt(num_mean_diff_estimands, 0) ? ((num_unique_entities * num_mean_diff_estimands) + 1) : 0 );
             for (size_t i_0__ = 0; i_0__ < entity_mean_diff_estimand_csr_row_pos_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_mean_diff_estimand_csr_row_pos[i_0__]", entity_mean_diff_estimand_csr_row_pos[i_0__], 1);
             }
-            current_statement_begin__ = 765;
+            current_statement_begin__ = 766;
             size_t entity_utility_diff_estimand_ids_i_0_max__ = ((num_utility_diff_estimands * 2) * num_unique_entities);
             for (size_t i_0__ = 0; i_0__ < entity_utility_diff_estimand_ids_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_utility_diff_estimand_ids[i_0__]", entity_utility_diff_estimand_ids[i_0__], 1);
                 check_less_or_equal(function__, "entity_utility_diff_estimand_ids[i_0__]", entity_utility_diff_estimand_ids[i_0__], (num_discretized_groups * num_unique_entities));
             }
-            current_statement_begin__ = 766;
+            current_statement_begin__ = 767;
             size_t entity_utility_diff_estimand_csr_row_pos_i_0_max__ = (logical_gt(num_utility_diff_estimands, 0) ? ((num_unique_entities * num_utility_diff_estimands) + 1) : 0 );
             for (size_t i_0__ = 0; i_0__ < entity_utility_diff_estimand_csr_row_pos_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_utility_diff_estimand_csr_row_pos[i_0__]", entity_utility_diff_estimand_csr_row_pos[i_0__], 1);
             }
-            current_statement_begin__ = 768;
+            current_statement_begin__ = 769;
             check_greater_or_equal(function__, "discrete_marginal_prob_csr_vec", discrete_marginal_prob_csr_vec, 0);
             check_less_or_equal(function__, "discrete_marginal_prob_csr_vec", discrete_marginal_prob_csr_vec, 1);
-            current_statement_begin__ = 769;
+            current_statement_begin__ = 770;
             size_t entity_discrete_marginal_prob_ids_i_0_max__ = ((num_discrete_r_types * num_joint_discrete_combo_members) * num_unique_entities);
             for (size_t i_0__ = 0; i_0__ < entity_discrete_marginal_prob_ids_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_discrete_marginal_prob_ids[i_0__]", entity_discrete_marginal_prob_ids[i_0__], 1);
                 check_less_or_equal(function__, "entity_discrete_marginal_prob_ids[i_0__]", entity_discrete_marginal_prob_ids[i_0__], (num_r_types * num_unique_entities));
             }
-            current_statement_begin__ = 770;
+            current_statement_begin__ = 771;
             size_t entity_discrete_marginal_prob_csr_row_pos_i_0_max__ = (num_discrete_r_types + 1);
             for (size_t i_0__ = 0; i_0__ < entity_discrete_marginal_prob_csr_row_pos_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_discrete_marginal_prob_csr_row_pos[i_0__]", entity_discrete_marginal_prob_csr_row_pos[i_0__], 1);
             }
-            current_statement_begin__ = 772;
+            current_statement_begin__ = 773;
             check_greater_or_equal(function__, "total_num_discrete_bg_variable_types", total_num_discrete_bg_variable_types, 1);
-            current_statement_begin__ = 774;
+            current_statement_begin__ = 775;
             check_greater_or_equal(function__, "single_discrete_marginal_prob_csr_vec", single_discrete_marginal_prob_csr_vec, 0);
             check_less_or_equal(function__, "single_discrete_marginal_prob_csr_vec", single_discrete_marginal_prob_csr_vec, 1);
-            current_statement_begin__ = 775;
+            current_statement_begin__ = 776;
             size_t entity_single_discrete_marginal_prob_ids_i_0_max__ = (sum(num_discrete_bg_variable_type_combo_members) * num_unique_entities);
             for (size_t i_0__ = 0; i_0__ < entity_single_discrete_marginal_prob_ids_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_single_discrete_marginal_prob_ids[i_0__]", entity_single_discrete_marginal_prob_ids[i_0__], 1);
                 check_less_or_equal(function__, "entity_single_discrete_marginal_prob_ids[i_0__]", entity_single_discrete_marginal_prob_ids[i_0__], (num_r_types * num_unique_entities));
             }
-            current_statement_begin__ = 776;
+            current_statement_begin__ = 777;
             size_t entity_single_discrete_marginal_prob_csr_row_pos_i_0_max__ = (total_num_discrete_bg_variable_types + 1);
             for (size_t i_0__ = 0; i_0__ < entity_single_discrete_marginal_prob_csr_row_pos_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_single_discrete_marginal_prob_csr_row_pos[i_0__]", entity_single_discrete_marginal_prob_csr_row_pos[i_0__], 1);
             }
-            current_statement_begin__ = 778;
+            current_statement_begin__ = 779;
             check_greater_or_equal(function__, "discretized_marginal_prob_csr_vec", discretized_marginal_prob_csr_vec, 0);
             check_less_or_equal(function__, "discretized_marginal_prob_csr_vec", discretized_marginal_prob_csr_vec, 1);
-            current_statement_begin__ = 779;
+            current_statement_begin__ = 780;
             size_t entity_discretized_marginal_prob_ids_i_0_max__ = (sum(num_discretized_bg_variable_type_combo_members) * num_unique_entities);
             for (size_t i_0__ = 0; i_0__ < entity_discretized_marginal_prob_ids_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_discretized_marginal_prob_ids[i_0__]", entity_discretized_marginal_prob_ids[i_0__], 1);
                 check_less_or_equal(function__, "entity_discretized_marginal_prob_ids[i_0__]", entity_discretized_marginal_prob_ids[i_0__], (num_r_types * num_unique_entities));
             }
-            current_statement_begin__ = 780;
+            current_statement_begin__ = 781;
             size_t entity_discretized_marginal_prob_csr_row_pos_i_0_max__ = (logical_gt(total_num_discretized_bg_variable_types, 0) ? (total_num_discretized_bg_variable_types + 1) : 0 );
             for (size_t i_0__ = 0; i_0__ < entity_discretized_marginal_prob_csr_row_pos_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_discretized_marginal_prob_csr_row_pos[i_0__]", entity_discretized_marginal_prob_csr_row_pos[i_0__], 1);
             }
-            current_statement_begin__ = 782;
+            current_statement_begin__ = 783;
             check_greater_or_equal(function__, "level_estimands_csr_vec", level_estimands_csr_vec, 0);
             check_less_or_equal(function__, "level_estimands_csr_vec", level_estimands_csr_vec, 1);
-            current_statement_begin__ = 783;
+            current_statement_begin__ = 784;
             size_t entity_estimand_ids_i_0_max__ = ((num_all_estimands * num_unique_entities) * num_estimand_levels);
             for (size_t i_0__ = 0; i_0__ < entity_estimand_ids_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_estimand_ids[i_0__]", entity_estimand_ids[i_0__], 1);
                 check_less_or_equal(function__, "entity_estimand_ids[i_0__]", entity_estimand_ids[i_0__], (num_all_estimands * num_unique_entities));
             }
-            current_statement_begin__ = 784;
+            current_statement_begin__ = 785;
             size_t entity_estimand_csr_row_pos_i_0_max__ = (logical_gt(num_estimand_levels, 0) ? ((num_all_estimands * sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list()), "level_size"))) + 1) : 0 );
             for (size_t i_0__ = 0; i_0__ < entity_estimand_csr_row_pos_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_estimand_csr_row_pos[i_0__]", entity_estimand_csr_row_pos[i_0__], 1);
             }
-            current_statement_begin__ = 786;
+            current_statement_begin__ = 787;
             check_greater_or_equal(function__, "entity_histogram_vec", entity_histogram_vec, -(1));
             check_less_or_equal(function__, "entity_histogram_vec", entity_histogram_vec, 1);
-            current_statement_begin__ = 787;
+            current_statement_begin__ = 788;
             size_t entity_histogram_ids_i_0_max__ = ((num_discretized_groups * ((2 * num_discretized_variables) + 1)) * num_unique_entities);
             for (size_t i_0__ = 0; i_0__ < entity_histogram_ids_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_histogram_ids[i_0__]", entity_histogram_ids[i_0__], 1);
                 check_less_or_equal(function__, "entity_histogram_ids[i_0__]", entity_histogram_ids[i_0__], ((num_atom_estimands * num_unique_entities) + 1));
             }
-            current_statement_begin__ = 788;
+            current_statement_begin__ = 789;
             size_t entity_histogram_csr_row_pos_i_0_max__ = (logical_gt(num_discretized_groups, 0) ? (((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities) + 1) : 0 );
             for (size_t i_0__ = 0; i_0__ < entity_histogram_csr_row_pos_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_histogram_csr_row_pos[i_0__]", entity_histogram_csr_row_pos[i_0__], 1);
             }
-            current_statement_begin__ = 790;
+            current_statement_begin__ = 791;
             check_greater_or_equal(function__, "entity_midpoint_vec", entity_midpoint_vec, min(cutpoint_midpoints));
             check_less_or_equal(function__, "entity_midpoint_vec", entity_midpoint_vec, max(cutpoint_midpoints));
-            current_statement_begin__ = 791;
+            current_statement_begin__ = 792;
             size_t entity_midpoint_ids_i_0_max__ = ((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities);
             for (size_t i_0__ = 0; i_0__ < entity_midpoint_ids_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_midpoint_ids[i_0__]", entity_midpoint_ids[i_0__], 1);
                 check_less_or_equal(function__, "entity_midpoint_ids[i_0__]", entity_midpoint_ids[i_0__], ((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities));
             }
-            current_statement_begin__ = 792;
+            current_statement_begin__ = 793;
             size_t entity_midpoint_csr_row_pos_i_0_max__ = (logical_gt(num_discretized_groups, 0) ? ((num_discretized_groups * num_unique_entities) + 1) : 0 );
             for (size_t i_0__ = 0; i_0__ < entity_midpoint_csr_row_pos_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "entity_midpoint_csr_row_pos[i_0__]", entity_midpoint_csr_row_pos[i_0__], 1);
             }
-            current_statement_begin__ = 794;
+            current_statement_begin__ = 795;
             check_greater_or_equal(function__, "entity_utility_vec", entity_utility_vec, min(utility));
             check_less_or_equal(function__, "entity_utility_vec", entity_utility_vec, max(utility));
-            current_statement_begin__ = 796;
+            current_statement_begin__ = 797;
             check_greater_or_equal(function__, "between_entity_diff_csr_vec", between_entity_diff_csr_vec, -(1));
             check_less_or_equal(function__, "between_entity_diff_csr_vec", between_entity_diff_csr_vec, 1);
-            current_statement_begin__ = 798;
+            current_statement_begin__ = 799;
             size_t between_entity_diff_csr_ids_i_0_max__ = ((2 * num_atom_estimands) * (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), "level_size")) - num_between_entity_diff_levels));
             for (size_t i_0__ = 0; i_0__ < between_entity_diff_csr_ids_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "between_entity_diff_csr_ids[i_0__]", between_entity_diff_csr_ids[i_0__], 1);
                 check_less_or_equal(function__, "between_entity_diff_csr_ids[i_0__]", between_entity_diff_csr_ids[i_0__], (num_all_estimands * sum(level_size)));
             }
-            current_statement_begin__ = 799;
+            current_statement_begin__ = 800;
             size_t between_entity_diff_csr_row_pos_i_0_max__ = (logical_gt(num_between_entity_diff_levels, 0) ? ((num_atom_estimands * (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), "level_size")) - num_between_entity_diff_levels)) + 1) : 0 );
             for (size_t i_0__ = 0; i_0__ < between_entity_diff_csr_row_pos_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "between_entity_diff_csr_row_pos[i_0__]", between_entity_diff_csr_row_pos[i_0__], 1);
@@ -4245,27 +4256,27 @@ public:
             // validate, set parameter ranges
             num_params_r__ = 0U;
             param_ranges_i__.clear();
-            current_statement_begin__ = 1190;
+            current_statement_begin__ = 1191;
             validate_non_negative_index("toplevel_discrete_beta", "num_discrete_r_types", num_discrete_r_types);
             num_params_r__ += num_discrete_r_types;
-            current_statement_begin__ = 1192;
+            current_statement_begin__ = 1193;
             validate_non_negative_index("discrete_level_beta_raw", "num_discrete_r_types", num_discrete_r_types);
             validate_non_negative_index("discrete_level_beta_raw", "sum(level_size)", sum(level_size));
             num_params_r__ += (num_discrete_r_types * sum(level_size));
-            current_statement_begin__ = 1193;
+            current_statement_begin__ = 1194;
             validate_non_negative_index("discrete_level_beta_sigma", "num_discrete_r_types", num_discrete_r_types);
             validate_non_negative_index("discrete_level_beta_sigma", "num_levels", num_levels);
             num_params_r__ += (num_discrete_r_types * num_levels);
-            current_statement_begin__ = 1196;
+            current_statement_begin__ = 1197;
             validate_non_negative_index("toplevel_discretized_beta", "sum(num_discretized_types_conditional)", sum(num_discretized_types_conditional));
             validate_non_negative_index("toplevel_discretized_beta", "num_discretized_variables", num_discretized_variables);
             num_params_r__ += (sum(num_discretized_types_conditional) * num_discretized_variables);
-            current_statement_begin__ = 1199;
+            current_statement_begin__ = 1200;
             validate_non_negative_index("discretized_level_beta_raw", "sum(num_discretized_types_conditional)", sum(num_discretized_types_conditional));
             validate_non_negative_index("discretized_level_beta_raw", "sum(level_size)", sum(level_size));
             validate_non_negative_index("discretized_level_beta_raw", "num_discretized_variables", num_discretized_variables);
             num_params_r__ += ((sum(num_discretized_types_conditional) * sum(level_size)) * num_discretized_variables);
-            current_statement_begin__ = 1200;
+            current_statement_begin__ = 1201;
             validate_non_negative_index("discretized_level_beta_sigma", "num_discretized_r_types", num_discretized_r_types);
             validate_non_negative_index("discretized_level_beta_sigma", "num_levels", num_levels);
             validate_non_negative_index("discretized_level_beta_sigma", "num_discretized_variables", num_discretized_variables);
@@ -4287,7 +4298,7 @@ public:
         (void) pos__; // dummy call to supress warning
         std::vector<double> vals_r__;
         std::vector<int> vals_i__;
-        current_statement_begin__ = 1190;
+        current_statement_begin__ = 1191;
         if (!(context__.contains_r("toplevel_discrete_beta")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable toplevel_discrete_beta missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("toplevel_discrete_beta");
@@ -4304,7 +4315,7 @@ public:
         } catch (const std::exception& e) {
             stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable toplevel_discrete_beta: ") + e.what()), current_statement_begin__, prog_reader__());
         }
-        current_statement_begin__ = 1192;
+        current_statement_begin__ = 1193;
         if (!(context__.contains_r("discrete_level_beta_raw")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable discrete_level_beta_raw missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("discrete_level_beta_raw");
@@ -4325,7 +4336,7 @@ public:
         } catch (const std::exception& e) {
             stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable discrete_level_beta_raw: ") + e.what()), current_statement_begin__, prog_reader__());
         }
-        current_statement_begin__ = 1193;
+        current_statement_begin__ = 1194;
         if (!(context__.contains_r("discrete_level_beta_sigma")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable discrete_level_beta_sigma missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("discrete_level_beta_sigma");
@@ -4346,7 +4357,7 @@ public:
         } catch (const std::exception& e) {
             stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable discrete_level_beta_sigma: ") + e.what()), current_statement_begin__, prog_reader__());
         }
-        current_statement_begin__ = 1196;
+        current_statement_begin__ = 1197;
         if (!(context__.contains_r("toplevel_discretized_beta")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable toplevel_discretized_beta missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("toplevel_discretized_beta");
@@ -4370,7 +4381,7 @@ public:
                 stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable toplevel_discretized_beta: ") + e.what()), current_statement_begin__, prog_reader__());
             }
         }
-        current_statement_begin__ = 1199;
+        current_statement_begin__ = 1200;
         if (!(context__.contains_r("discretized_level_beta_raw")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable discretized_level_beta_raw missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("discretized_level_beta_raw");
@@ -4398,7 +4409,7 @@ public:
                 stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable discretized_level_beta_raw: ") + e.what()), current_statement_begin__, prog_reader__());
             }
         }
-        current_statement_begin__ = 1200;
+        current_statement_begin__ = 1201;
         if (!(context__.contains_r("discretized_level_beta_sigma")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable discretized_level_beta_sigma missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("discretized_level_beta_sigma");
@@ -4451,28 +4462,28 @@ public:
         try {
             stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
             // model parameters
-            current_statement_begin__ = 1190;
+            current_statement_begin__ = 1191;
             Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> toplevel_discrete_beta;
             (void) toplevel_discrete_beta;  // dummy to suppress unused var warning
             if (jacobian__)
                 toplevel_discrete_beta = in__.vector_constrain(num_discrete_r_types, lp__);
             else
                 toplevel_discrete_beta = in__.vector_constrain(num_discrete_r_types);
-            current_statement_begin__ = 1192;
+            current_statement_begin__ = 1193;
             Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, Eigen::Dynamic> discrete_level_beta_raw;
             (void) discrete_level_beta_raw;  // dummy to suppress unused var warning
             if (jacobian__)
                 discrete_level_beta_raw = in__.matrix_constrain(num_discrete_r_types, sum(level_size), lp__);
             else
                 discrete_level_beta_raw = in__.matrix_constrain(num_discrete_r_types, sum(level_size));
-            current_statement_begin__ = 1193;
+            current_statement_begin__ = 1194;
             Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, Eigen::Dynamic> discrete_level_beta_sigma;
             (void) discrete_level_beta_sigma;  // dummy to suppress unused var warning
             if (jacobian__)
                 discrete_level_beta_sigma = in__.matrix_lb_constrain(0, num_discrete_r_types, num_levels, lp__);
             else
                 discrete_level_beta_sigma = in__.matrix_lb_constrain(0, num_discrete_r_types, num_levels);
-            current_statement_begin__ = 1196;
+            current_statement_begin__ = 1197;
             std::vector<Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> > toplevel_discretized_beta;
             size_t toplevel_discretized_beta_d_0_max__ = num_discretized_variables;
             toplevel_discretized_beta.reserve(toplevel_discretized_beta_d_0_max__);
@@ -4482,7 +4493,7 @@ public:
                 else
                     toplevel_discretized_beta.push_back(in__.vector_constrain(sum(num_discretized_types_conditional)));
             }
-            current_statement_begin__ = 1199;
+            current_statement_begin__ = 1200;
             std::vector<Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, Eigen::Dynamic> > discretized_level_beta_raw;
             size_t discretized_level_beta_raw_d_0_max__ = num_discretized_variables;
             discretized_level_beta_raw.reserve(discretized_level_beta_raw_d_0_max__);
@@ -4492,7 +4503,7 @@ public:
                 else
                     discretized_level_beta_raw.push_back(in__.matrix_constrain(sum(num_discretized_types_conditional), sum(level_size)));
             }
-            current_statement_begin__ = 1200;
+            current_statement_begin__ = 1201;
             std::vector<Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, Eigen::Dynamic> > discretized_level_beta_sigma;
             size_t discretized_level_beta_sigma_d_0_max__ = num_discretized_variables;
             discretized_level_beta_sigma.reserve(discretized_level_beta_sigma_d_0_max__);
@@ -4503,24 +4514,24 @@ public:
                     discretized_level_beta_sigma.push_back(in__.matrix_lb_constrain(0, num_discretized_r_types, num_levels));
             }
             // transformed parameters
-            current_statement_begin__ = 1204;
+            current_statement_begin__ = 1205;
             validate_non_negative_index("r_log_prob", "(num_r_types * num_unique_entities)", (num_r_types * num_unique_entities));
             Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> r_log_prob((num_r_types * num_unique_entities));
             stan::math::initialize(r_log_prob, DUMMY_VAR__);
             stan::math::fill(r_log_prob, DUMMY_VAR__);
-            current_statement_begin__ = 1206;
+            current_statement_begin__ = 1207;
             validate_non_negative_index("entity_candidates_group_logp", "(logical_eq(run_type, RUN_TYPE_FIT) ? sum(num_unique_entity_candidate_groups) : 0 )", (logical_eq(run_type, RUN_TYPE_FIT) ? sum(num_unique_entity_candidate_groups) : 0 ));
             Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> entity_candidates_group_logp((logical_eq(run_type, RUN_TYPE_FIT) ? sum(num_unique_entity_candidate_groups) : 0 ));
             stan::math::initialize(entity_candidates_group_logp, DUMMY_VAR__);
             stan::math::fill(entity_candidates_group_logp, DUMMY_VAR__);
-            current_statement_begin__ = 1208;
+            current_statement_begin__ = 1209;
             validate_non_negative_index("discrete_beta", "num_discrete_r_types", num_discrete_r_types);
             validate_non_negative_index("discrete_beta", "num_unique_entities", num_unique_entities);
             Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, Eigen::Dynamic> discrete_beta(num_discrete_r_types, num_unique_entities);
             stan::math::initialize(discrete_beta, DUMMY_VAR__);
             stan::math::fill(discrete_beta, DUMMY_VAR__);
             stan::math::assign(discrete_beta,rep_matrix(toplevel_discrete_beta, num_unique_entities));
-            current_statement_begin__ = 1211;
+            current_statement_begin__ = 1212;
             validate_non_negative_index("discretized_beta", "sum(num_discretized_types_conditional)", sum(num_discretized_types_conditional));
             validate_non_negative_index("discretized_beta", "num_unique_entities", num_unique_entities);
             validate_non_negative_index("discretized_beta", "num_discretized_variables", num_discretized_variables);
@@ -4528,85 +4539,85 @@ public:
             stan::math::initialize(discretized_beta, DUMMY_VAR__);
             stan::math::fill(discretized_beta, DUMMY_VAR__);
             // transformed parameters block statements
-            current_statement_begin__ = 1213;
+            current_statement_begin__ = 1214;
             for (int discretized_var_index = 1; discretized_var_index <= num_discretized_variables; ++discretized_var_index) {
-                current_statement_begin__ = 1229;
+                current_statement_begin__ = 1230;
                 stan::model::assign(discretized_beta, 
                             stan::model::cons_list(stan::model::index_uni(discretized_var_index), stan::model::nil_index_list()), 
                             rep_matrix(get_base1(toplevel_discretized_beta, discretized_var_index, "toplevel_discretized_beta", 1), num_unique_entities), 
                             "assigning variable discretized_beta");
             }
-            current_statement_begin__ = 1232;
+            current_statement_begin__ = 1233;
             if (as_bool(logical_gt(num_levels, 0))) {
                 {
-                current_statement_begin__ = 1233;
+                current_statement_begin__ = 1234;
                 int level_entity_pos(0);
                 (void) level_entity_pos;  // dummy to suppress unused var warning
                 stan::math::fill(level_entity_pos, std::numeric_limits<int>::min());
                 stan::math::assign(level_entity_pos,1);
-                current_statement_begin__ = 1235;
+                current_statement_begin__ = 1236;
                 for (int level_index = 1; level_index <= num_levels; ++level_index) {
                     {
-                    current_statement_begin__ = 1236;
+                    current_statement_begin__ = 1237;
                     int level_entity_end(0);
                     (void) level_entity_end;  // dummy to suppress unused var warning
                     stan::math::fill(level_entity_end, std::numeric_limits<int>::min());
                     stan::math::assign(level_entity_end,((level_entity_pos + get_base1(level_size, level_index, "level_size", 1)) - 1));
-                    current_statement_begin__ = 1238;
+                    current_statement_begin__ = 1239;
                     validate_non_negative_index("curr_discrete_level_beta", "num_discrete_r_types", num_discrete_r_types);
                     validate_non_negative_index("curr_discrete_level_beta", "get_base1(level_size, level_index, \"level_size\", 1)", get_base1(level_size, level_index, "level_size", 1));
                     Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, Eigen::Dynamic> curr_discrete_level_beta(num_discrete_r_types, get_base1(level_size, level_index, "level_size", 1));
                     stan::math::initialize(curr_discrete_level_beta, DUMMY_VAR__);
                     stan::math::fill(curr_discrete_level_beta, DUMMY_VAR__);
                     stan::math::assign(curr_discrete_level_beta,elt_multiply(stan::model::rvalue(discrete_level_beta_raw, stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_min_max(level_entity_pos, level_entity_end), stan::model::nil_index_list())), "discrete_level_beta_raw"), rep_matrix(stan::model::rvalue(discrete_level_beta_sigma, stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(level_index), stan::model::nil_index_list())), "discrete_level_beta_sigma"), get_base1(level_size, level_index, "level_size", 1))));
-                    current_statement_begin__ = 1241;
+                    current_statement_begin__ = 1242;
                     stan::math::assign(discrete_beta, add(discrete_beta, stan::model::rvalue(curr_discrete_level_beta, stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_multi(stan::model::rvalue(unique_entity_ids, stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(level_index), stan::model::nil_index_list())), "unique_entity_ids")), stan::model::nil_index_list())), "curr_discrete_level_beta")));
-                    current_statement_begin__ = 1243;
+                    current_statement_begin__ = 1244;
                     for (int discretized_var_index = 1; discretized_var_index <= num_discretized_variables; ++discretized_var_index) {
                         {
-                        current_statement_begin__ = 1244;
+                        current_statement_begin__ = 1245;
                         validate_non_negative_index("curr_discretized_level_beta", "sum(num_discretized_types_conditional)", sum(num_discretized_types_conditional));
                         validate_non_negative_index("curr_discretized_level_beta", "get_base1(level_size, level_index, \"level_size\", 1)", get_base1(level_size, level_index, "level_size", 1));
                         Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, Eigen::Dynamic> curr_discretized_level_beta(sum(num_discretized_types_conditional), get_base1(level_size, level_index, "level_size", 1));
                         stan::math::initialize(curr_discretized_level_beta, DUMMY_VAR__);
                         stan::math::fill(curr_discretized_level_beta, DUMMY_VAR__);
                         stan::math::assign(curr_discretized_level_beta,elt_multiply(stan::model::rvalue(discretized_level_beta_raw, stan::model::cons_list(stan::model::index_uni(discretized_var_index), stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_min_max(level_entity_pos, level_entity_end), stan::model::nil_index_list()))), "discretized_level_beta_raw"), rep_matrix(stan::model::rvalue(discretized_level_beta_sigma, stan::model::cons_list(stan::model::index_uni(discretized_var_index), stan::model::cons_list(stan::model::index_multi(discretized_types_conditional), stan::model::cons_list(stan::model::index_uni(level_index), stan::model::nil_index_list()))), "discretized_level_beta_sigma"), get_base1(level_size, level_index, "level_size", 1))));
-                        current_statement_begin__ = 1252;
+                        current_statement_begin__ = 1253;
                         stan::model::assign(discretized_beta, 
                                     stan::model::cons_list(stan::model::index_uni(discretized_var_index), stan::model::nil_index_list()), 
                                     add(stan::model::rvalue(discretized_beta, stan::model::cons_list(stan::model::index_uni(discretized_var_index), stan::model::nil_index_list()), "discretized_beta"), stan::model::rvalue(curr_discretized_level_beta, stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_multi(stan::model::rvalue(unique_entity_ids, stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(level_index), stan::model::nil_index_list())), "unique_entity_ids")), stan::model::nil_index_list())), "curr_discretized_level_beta")), 
                                     "assigning variable discretized_beta");
                         }
                     }
-                    current_statement_begin__ = 1255;
+                    current_statement_begin__ = 1256;
                     stan::math::assign(level_entity_pos, (level_entity_end + 1));
                     }
                 }
                 }
             }
-            current_statement_begin__ = 1259;
+            current_statement_begin__ = 1260;
             for (int entity_index = 1; entity_index <= num_unique_entities; ++entity_index) {
                 {
-                current_statement_begin__ = 1260;
+                current_statement_begin__ = 1261;
                 validate_non_negative_index("curr_discrete_log_prob", "num_discrete_r_types", num_discrete_r_types);
                 Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> curr_discrete_log_prob(num_discrete_r_types);
                 stan::math::initialize(curr_discrete_log_prob, DUMMY_VAR__);
                 stan::math::fill(curr_discrete_log_prob, DUMMY_VAR__);
                 stan::math::assign(curr_discrete_log_prob,log_softmax(stan::model::rvalue(discrete_beta, stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(entity_index), stan::model::nil_index_list())), "discrete_beta")));
-                current_statement_begin__ = 1262;
+                current_statement_begin__ = 1263;
                 if (as_bool(logical_gt(num_discretized_r_types, 0))) {
                     {
-                    current_statement_begin__ = 1263;
+                    current_statement_begin__ = 1264;
                     int r_prob_pos(0);
                     (void) r_prob_pos;  // dummy to suppress unused var warning
                     stan::math::fill(r_prob_pos, std::numeric_limits<int>::min());
                     stan::math::assign(r_prob_pos,(((entity_index - 1) * num_r_types) + 1));
-                    current_statement_begin__ = 1264;
+                    current_statement_begin__ = 1265;
                     int r_prob_end(0);
                     (void) r_prob_end;  // dummy to suppress unused var warning
                     stan::math::fill(r_prob_end, std::numeric_limits<int>::min());
                     stan::math::assign(r_prob_end,(entity_index * num_r_types));
-                    current_statement_begin__ = 1266;
+                    current_statement_begin__ = 1267;
                     stan::model::assign(r_log_prob, 
                                 stan::model::cons_list(stan::model::index_min_max(r_prob_pos, r_prob_end), stan::model::nil_index_list()), 
                                 calculate_r_type_joint_log_prob(num_r_types, num_discrete_r_types, num_discretized_r_types, discrete_group_size, num_discretized_types_conditional, discretized_types_conditional, num_compatible_discretized_r_types, compatible_discretized_r_types, compatible_discretized_pair_ids, curr_discrete_log_prob, discretized_beta, entity_index, pstream__), 
@@ -4614,17 +4625,17 @@ public:
                     }
                 } else {
                     {
-                    current_statement_begin__ = 1271;
+                    current_statement_begin__ = 1272;
                     int r_prob_pos(0);
                     (void) r_prob_pos;  // dummy to suppress unused var warning
                     stan::math::fill(r_prob_pos, std::numeric_limits<int>::min());
                     stan::math::assign(r_prob_pos,(((entity_index - 1) * num_r_types) + 1));
-                    current_statement_begin__ = 1272;
+                    current_statement_begin__ = 1273;
                     int r_prob_end(0);
                     (void) r_prob_end;  // dummy to suppress unused var warning
                     stan::math::fill(r_prob_end, std::numeric_limits<int>::min());
                     stan::math::assign(r_prob_end,(entity_index * num_r_types));
-                    current_statement_begin__ = 1274;
+                    current_statement_begin__ = 1275;
                     stan::model::assign(r_log_prob, 
                                 stan::model::cons_list(stan::model::index_min_max(r_prob_pos, r_prob_end), stan::model::nil_index_list()), 
                                 stan::model::rvalue(curr_discrete_log_prob, stan::model::cons_list(stan::model::index_multi(discrete_r_type_id), stan::model::nil_index_list()), "curr_discrete_log_prob"), 
@@ -4633,15 +4644,15 @@ public:
                 }
                 }
             }
-            current_statement_begin__ = 1278;
+            current_statement_begin__ = 1279;
             if (as_bool(logical_eq(run_type, RUN_TYPE_FIT))) {
-                current_statement_begin__ = 1279;
+                current_statement_begin__ = 1280;
                 stan::math::assign(entity_candidates_group_logp, csr_log_sum_exp(sum(num_unique_entity_candidate_groups), (num_r_types * num_unique_entities), entity_candidate_group_ids, entity_candidate_group_csr_row_pos, r_log_prob, pstream__));
             }
             // validate transformed parameters
             const char* function__ = "validate transformed params";
             (void) function__;  // dummy to suppress unused var warning
-            current_statement_begin__ = 1204;
+            current_statement_begin__ = 1205;
             size_t r_log_prob_j_1_max__ = (num_r_types * num_unique_entities);
             for (size_t j_1__ = 0; j_1__ < r_log_prob_j_1_max__; ++j_1__) {
                 if (stan::math::is_uninitialized(r_log_prob(j_1__))) {
@@ -4651,7 +4662,7 @@ public:
                 }
             }
             check_less_or_equal(function__, "r_log_prob", r_log_prob, 0);
-            current_statement_begin__ = 1206;
+            current_statement_begin__ = 1207;
             size_t entity_candidates_group_logp_j_1_max__ = (logical_eq(run_type, RUN_TYPE_FIT) ? sum(num_unique_entity_candidate_groups) : 0 );
             for (size_t j_1__ = 0; j_1__ < entity_candidates_group_logp_j_1_max__; ++j_1__) {
                 if (stan::math::is_uninitialized(entity_candidates_group_logp(j_1__))) {
@@ -4660,7 +4671,7 @@ public:
                     stan::lang::rethrow_located(std::runtime_error(std::string("Error initializing variable entity_candidates_group_logp: ") + msg__.str()), current_statement_begin__, prog_reader__());
                 }
             }
-            current_statement_begin__ = 1208;
+            current_statement_begin__ = 1209;
             size_t discrete_beta_j_1_max__ = num_discrete_r_types;
             size_t discrete_beta_j_2_max__ = num_unique_entities;
             for (size_t j_1__ = 0; j_1__ < discrete_beta_j_1_max__; ++j_1__) {
@@ -4672,7 +4683,7 @@ public:
                     }
                 }
             }
-            current_statement_begin__ = 1211;
+            current_statement_begin__ = 1212;
             size_t discretized_beta_k_0_max__ = num_discretized_variables;
             size_t discretized_beta_j_1_max__ = sum(num_discretized_types_conditional);
             size_t discretized_beta_j_2_max__ = num_unique_entities;
@@ -4688,55 +4699,55 @@ public:
                 }
             }
             // model body
-            current_statement_begin__ = 1288;
-            lp_accum__.add(normal_log<propto__>(toplevel_discrete_beta, 0, discrete_beta_hyper_sd));
-            current_statement_begin__ = 1290;
+            current_statement_begin__ = 1289;
+            lp_accum__.add(normal_log<propto__>(toplevel_discrete_beta, discrete_beta_hyper_mean, discrete_beta_hyper_sd));
+            current_statement_begin__ = 1291;
             if (as_bool(logical_gt(num_levels, 0))) {
-                current_statement_begin__ = 1291;
+                current_statement_begin__ = 1292;
                 lp_accum__.add(std_normal_log<propto__>(to_vector(discrete_level_beta_raw)));
-                current_statement_begin__ = 1293;
+                current_statement_begin__ = 1294;
                 for (int level_index = 1; level_index <= num_levels; ++level_index) {
-                    current_statement_begin__ = 1294;
+                    current_statement_begin__ = 1295;
                     lp_accum__.add(normal_log<propto__>(stan::model::rvalue(discrete_level_beta_sigma, stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(level_index), stan::model::nil_index_list())), "discrete_level_beta_sigma"), 0, get_base1(tau_level_sigma, level_index, "tau_level_sigma", 1)));
                 }
             }
-            current_statement_begin__ = 1298;
+            current_statement_begin__ = 1299;
             for (int discretized_var_index = 1; discretized_var_index <= num_discretized_variables; ++discretized_var_index) {
                 {
-                current_statement_begin__ = 1301;
+                current_statement_begin__ = 1302;
                 int discretized_beta_pos(0);
                 (void) discretized_beta_pos;  // dummy to suppress unused var warning
                 stan::math::fill(discretized_beta_pos, std::numeric_limits<int>::min());
                 stan::math::assign(discretized_beta_pos,1);
-                current_statement_begin__ = 1303;
+                current_statement_begin__ = 1304;
                 for (int discrete_type_index = 1; discrete_type_index <= num_discrete_r_types; ++discrete_type_index) {
                     {
-                    current_statement_begin__ = 1304;
+                    current_statement_begin__ = 1305;
                     int discretized_beta_end(0);
                     (void) discretized_beta_end;  // dummy to suppress unused var warning
                     stan::math::fill(discretized_beta_end, std::numeric_limits<int>::min());
                     stan::math::assign(discretized_beta_end,((discretized_beta_pos + get_base1(num_discretized_types_conditional, discrete_type_index, "num_discretized_types_conditional", 1)) - 1));
-                    current_statement_begin__ = 1306;
+                    current_statement_begin__ = 1307;
                     lp_accum__.add(normal_log<propto__>(stan::model::rvalue(toplevel_discretized_beta, stan::model::cons_list(stan::model::index_uni(discretized_var_index), stan::model::cons_list(stan::model::index_min_max(discretized_beta_pos, discretized_beta_end), stan::model::nil_index_list())), "toplevel_discretized_beta"), stan::model::rvalue(discretized_beta_hyper_mean, stan::model::cons_list(stan::model::index_multi(stan::model::rvalue(discretized_types_conditional, stan::model::cons_list(stan::model::index_min_max(discretized_beta_pos, discretized_beta_end), stan::model::nil_index_list()), "discretized_types_conditional")), stan::model::cons_list(stan::model::index_uni(discrete_type_index), stan::model::nil_index_list())), "discretized_beta_hyper_mean"), stan::model::rvalue(discretized_beta_hyper_sd, stan::model::cons_list(stan::model::index_multi(stan::model::rvalue(discretized_types_conditional, stan::model::cons_list(stan::model::index_min_max(discretized_beta_pos, discretized_beta_end), stan::model::nil_index_list()), "discretized_types_conditional")), stan::model::cons_list(stan::model::index_uni(discrete_type_index), stan::model::nil_index_list())), "discretized_beta_hyper_sd")));
-                    current_statement_begin__ = 1310;
+                    current_statement_begin__ = 1311;
                     stan::math::assign(discretized_beta_pos, (discretized_beta_end + 1));
                     }
                 }
-                current_statement_begin__ = 1313;
+                current_statement_begin__ = 1314;
                 if (as_bool(logical_gt(num_levels, 0))) {
-                    current_statement_begin__ = 1314;
+                    current_statement_begin__ = 1315;
                     lp_accum__.add(std_normal_log<propto__>(to_vector(get_base1(discretized_level_beta_raw, discretized_var_index, "discretized_level_beta_raw", 1))));
-                    current_statement_begin__ = 1316;
+                    current_statement_begin__ = 1317;
                     for (int level_index = 1; level_index <= num_levels; ++level_index) {
-                        current_statement_begin__ = 1317;
+                        current_statement_begin__ = 1318;
                         lp_accum__.add(normal_log<propto__>(stan::model::rvalue(discretized_level_beta_sigma, stan::model::cons_list(stan::model::index_uni(discretized_var_index), stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(level_index), stan::model::nil_index_list()))), "discretized_level_beta_sigma"), 0, get_base1(tau_level_sigma, level_index, "tau_level_sigma", 1)));
                     }
                 }
                 }
             }
-            current_statement_begin__ = 1322;
+            current_statement_begin__ = 1323;
             if (as_bool(logical_eq(run_type, RUN_TYPE_FIT))) {
-                current_statement_begin__ = 1323;
+                current_statement_begin__ = 1324;
                 lp_accum__.add(multiply(num_unique_entity_in_candidate_groups, entity_candidates_group_logp));
             }
         } catch (const std::exception& e) {
@@ -4980,24 +4991,24 @@ public:
         if (!include_tparams__ && !include_gqs__) return;
         try {
             // declare and define transformed parameters
-            current_statement_begin__ = 1204;
+            current_statement_begin__ = 1205;
             validate_non_negative_index("r_log_prob", "(num_r_types * num_unique_entities)", (num_r_types * num_unique_entities));
             Eigen::Matrix<double, Eigen::Dynamic, 1> r_log_prob((num_r_types * num_unique_entities));
             stan::math::initialize(r_log_prob, DUMMY_VAR__);
             stan::math::fill(r_log_prob, DUMMY_VAR__);
-            current_statement_begin__ = 1206;
+            current_statement_begin__ = 1207;
             validate_non_negative_index("entity_candidates_group_logp", "(logical_eq(run_type, RUN_TYPE_FIT) ? sum(num_unique_entity_candidate_groups) : 0 )", (logical_eq(run_type, RUN_TYPE_FIT) ? sum(num_unique_entity_candidate_groups) : 0 ));
             Eigen::Matrix<double, Eigen::Dynamic, 1> entity_candidates_group_logp((logical_eq(run_type, RUN_TYPE_FIT) ? sum(num_unique_entity_candidate_groups) : 0 ));
             stan::math::initialize(entity_candidates_group_logp, DUMMY_VAR__);
             stan::math::fill(entity_candidates_group_logp, DUMMY_VAR__);
-            current_statement_begin__ = 1208;
+            current_statement_begin__ = 1209;
             validate_non_negative_index("discrete_beta", "num_discrete_r_types", num_discrete_r_types);
             validate_non_negative_index("discrete_beta", "num_unique_entities", num_unique_entities);
             Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> discrete_beta(num_discrete_r_types, num_unique_entities);
             stan::math::initialize(discrete_beta, DUMMY_VAR__);
             stan::math::fill(discrete_beta, DUMMY_VAR__);
             stan::math::assign(discrete_beta,rep_matrix(toplevel_discrete_beta, num_unique_entities));
-            current_statement_begin__ = 1211;
+            current_statement_begin__ = 1212;
             validate_non_negative_index("discretized_beta", "sum(num_discretized_types_conditional)", sum(num_discretized_types_conditional));
             validate_non_negative_index("discretized_beta", "num_unique_entities", num_unique_entities);
             validate_non_negative_index("discretized_beta", "num_discretized_variables", num_discretized_variables);
@@ -5005,85 +5016,85 @@ public:
             stan::math::initialize(discretized_beta, DUMMY_VAR__);
             stan::math::fill(discretized_beta, DUMMY_VAR__);
             // do transformed parameters statements
-            current_statement_begin__ = 1213;
+            current_statement_begin__ = 1214;
             for (int discretized_var_index = 1; discretized_var_index <= num_discretized_variables; ++discretized_var_index) {
-                current_statement_begin__ = 1229;
+                current_statement_begin__ = 1230;
                 stan::model::assign(discretized_beta, 
                             stan::model::cons_list(stan::model::index_uni(discretized_var_index), stan::model::nil_index_list()), 
                             rep_matrix(get_base1(toplevel_discretized_beta, discretized_var_index, "toplevel_discretized_beta", 1), num_unique_entities), 
                             "assigning variable discretized_beta");
             }
-            current_statement_begin__ = 1232;
+            current_statement_begin__ = 1233;
             if (as_bool(logical_gt(num_levels, 0))) {
                 {
-                current_statement_begin__ = 1233;
+                current_statement_begin__ = 1234;
                 int level_entity_pos(0);
                 (void) level_entity_pos;  // dummy to suppress unused var warning
                 stan::math::fill(level_entity_pos, std::numeric_limits<int>::min());
                 stan::math::assign(level_entity_pos,1);
-                current_statement_begin__ = 1235;
+                current_statement_begin__ = 1236;
                 for (int level_index = 1; level_index <= num_levels; ++level_index) {
                     {
-                    current_statement_begin__ = 1236;
+                    current_statement_begin__ = 1237;
                     int level_entity_end(0);
                     (void) level_entity_end;  // dummy to suppress unused var warning
                     stan::math::fill(level_entity_end, std::numeric_limits<int>::min());
                     stan::math::assign(level_entity_end,((level_entity_pos + get_base1(level_size, level_index, "level_size", 1)) - 1));
-                    current_statement_begin__ = 1238;
+                    current_statement_begin__ = 1239;
                     validate_non_negative_index("curr_discrete_level_beta", "num_discrete_r_types", num_discrete_r_types);
                     validate_non_negative_index("curr_discrete_level_beta", "get_base1(level_size, level_index, \"level_size\", 1)", get_base1(level_size, level_index, "level_size", 1));
                     Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, Eigen::Dynamic> curr_discrete_level_beta(num_discrete_r_types, get_base1(level_size, level_index, "level_size", 1));
                     stan::math::initialize(curr_discrete_level_beta, DUMMY_VAR__);
                     stan::math::fill(curr_discrete_level_beta, DUMMY_VAR__);
                     stan::math::assign(curr_discrete_level_beta,elt_multiply(stan::model::rvalue(discrete_level_beta_raw, stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_min_max(level_entity_pos, level_entity_end), stan::model::nil_index_list())), "discrete_level_beta_raw"), rep_matrix(stan::model::rvalue(discrete_level_beta_sigma, stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(level_index), stan::model::nil_index_list())), "discrete_level_beta_sigma"), get_base1(level_size, level_index, "level_size", 1))));
-                    current_statement_begin__ = 1241;
+                    current_statement_begin__ = 1242;
                     stan::math::assign(discrete_beta, add(discrete_beta, stan::model::rvalue(curr_discrete_level_beta, stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_multi(stan::model::rvalue(unique_entity_ids, stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(level_index), stan::model::nil_index_list())), "unique_entity_ids")), stan::model::nil_index_list())), "curr_discrete_level_beta")));
-                    current_statement_begin__ = 1243;
+                    current_statement_begin__ = 1244;
                     for (int discretized_var_index = 1; discretized_var_index <= num_discretized_variables; ++discretized_var_index) {
                         {
-                        current_statement_begin__ = 1244;
+                        current_statement_begin__ = 1245;
                         validate_non_negative_index("curr_discretized_level_beta", "sum(num_discretized_types_conditional)", sum(num_discretized_types_conditional));
                         validate_non_negative_index("curr_discretized_level_beta", "get_base1(level_size, level_index, \"level_size\", 1)", get_base1(level_size, level_index, "level_size", 1));
                         Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, Eigen::Dynamic> curr_discretized_level_beta(sum(num_discretized_types_conditional), get_base1(level_size, level_index, "level_size", 1));
                         stan::math::initialize(curr_discretized_level_beta, DUMMY_VAR__);
                         stan::math::fill(curr_discretized_level_beta, DUMMY_VAR__);
                         stan::math::assign(curr_discretized_level_beta,elt_multiply(stan::model::rvalue(discretized_level_beta_raw, stan::model::cons_list(stan::model::index_uni(discretized_var_index), stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_min_max(level_entity_pos, level_entity_end), stan::model::nil_index_list()))), "discretized_level_beta_raw"), rep_matrix(stan::model::rvalue(discretized_level_beta_sigma, stan::model::cons_list(stan::model::index_uni(discretized_var_index), stan::model::cons_list(stan::model::index_multi(discretized_types_conditional), stan::model::cons_list(stan::model::index_uni(level_index), stan::model::nil_index_list()))), "discretized_level_beta_sigma"), get_base1(level_size, level_index, "level_size", 1))));
-                        current_statement_begin__ = 1252;
+                        current_statement_begin__ = 1253;
                         stan::model::assign(discretized_beta, 
                                     stan::model::cons_list(stan::model::index_uni(discretized_var_index), stan::model::nil_index_list()), 
                                     add(stan::model::rvalue(discretized_beta, stan::model::cons_list(stan::model::index_uni(discretized_var_index), stan::model::nil_index_list()), "discretized_beta"), stan::model::rvalue(curr_discretized_level_beta, stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_multi(stan::model::rvalue(unique_entity_ids, stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(level_index), stan::model::nil_index_list())), "unique_entity_ids")), stan::model::nil_index_list())), "curr_discretized_level_beta")), 
                                     "assigning variable discretized_beta");
                         }
                     }
-                    current_statement_begin__ = 1255;
+                    current_statement_begin__ = 1256;
                     stan::math::assign(level_entity_pos, (level_entity_end + 1));
                     }
                 }
                 }
             }
-            current_statement_begin__ = 1259;
+            current_statement_begin__ = 1260;
             for (int entity_index = 1; entity_index <= num_unique_entities; ++entity_index) {
                 {
-                current_statement_begin__ = 1260;
+                current_statement_begin__ = 1261;
                 validate_non_negative_index("curr_discrete_log_prob", "num_discrete_r_types", num_discrete_r_types);
                 Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> curr_discrete_log_prob(num_discrete_r_types);
                 stan::math::initialize(curr_discrete_log_prob, DUMMY_VAR__);
                 stan::math::fill(curr_discrete_log_prob, DUMMY_VAR__);
                 stan::math::assign(curr_discrete_log_prob,log_softmax(stan::model::rvalue(discrete_beta, stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(entity_index), stan::model::nil_index_list())), "discrete_beta")));
-                current_statement_begin__ = 1262;
+                current_statement_begin__ = 1263;
                 if (as_bool(logical_gt(num_discretized_r_types, 0))) {
                     {
-                    current_statement_begin__ = 1263;
+                    current_statement_begin__ = 1264;
                     int r_prob_pos(0);
                     (void) r_prob_pos;  // dummy to suppress unused var warning
                     stan::math::fill(r_prob_pos, std::numeric_limits<int>::min());
                     stan::math::assign(r_prob_pos,(((entity_index - 1) * num_r_types) + 1));
-                    current_statement_begin__ = 1264;
+                    current_statement_begin__ = 1265;
                     int r_prob_end(0);
                     (void) r_prob_end;  // dummy to suppress unused var warning
                     stan::math::fill(r_prob_end, std::numeric_limits<int>::min());
                     stan::math::assign(r_prob_end,(entity_index * num_r_types));
-                    current_statement_begin__ = 1266;
+                    current_statement_begin__ = 1267;
                     stan::model::assign(r_log_prob, 
                                 stan::model::cons_list(stan::model::index_min_max(r_prob_pos, r_prob_end), stan::model::nil_index_list()), 
                                 calculate_r_type_joint_log_prob(num_r_types, num_discrete_r_types, num_discretized_r_types, discrete_group_size, num_discretized_types_conditional, discretized_types_conditional, num_compatible_discretized_r_types, compatible_discretized_r_types, compatible_discretized_pair_ids, curr_discrete_log_prob, discretized_beta, entity_index, pstream__), 
@@ -5091,17 +5102,17 @@ public:
                     }
                 } else {
                     {
-                    current_statement_begin__ = 1271;
+                    current_statement_begin__ = 1272;
                     int r_prob_pos(0);
                     (void) r_prob_pos;  // dummy to suppress unused var warning
                     stan::math::fill(r_prob_pos, std::numeric_limits<int>::min());
                     stan::math::assign(r_prob_pos,(((entity_index - 1) * num_r_types) + 1));
-                    current_statement_begin__ = 1272;
+                    current_statement_begin__ = 1273;
                     int r_prob_end(0);
                     (void) r_prob_end;  // dummy to suppress unused var warning
                     stan::math::fill(r_prob_end, std::numeric_limits<int>::min());
                     stan::math::assign(r_prob_end,(entity_index * num_r_types));
-                    current_statement_begin__ = 1274;
+                    current_statement_begin__ = 1275;
                     stan::model::assign(r_log_prob, 
                                 stan::model::cons_list(stan::model::index_min_max(r_prob_pos, r_prob_end), stan::model::nil_index_list()), 
                                 stan::model::rvalue(curr_discrete_log_prob, stan::model::cons_list(stan::model::index_multi(discrete_r_type_id), stan::model::nil_index_list()), "curr_discrete_log_prob"), 
@@ -5110,16 +5121,16 @@ public:
                 }
                 }
             }
-            current_statement_begin__ = 1278;
+            current_statement_begin__ = 1279;
             if (as_bool(logical_eq(run_type, RUN_TYPE_FIT))) {
-                current_statement_begin__ = 1279;
+                current_statement_begin__ = 1280;
                 stan::math::assign(entity_candidates_group_logp, csr_log_sum_exp(sum(num_unique_entity_candidate_groups), (num_r_types * num_unique_entities), entity_candidate_group_ids, entity_candidate_group_csr_row_pos, r_log_prob, pstream__));
             }
             if (!include_gqs__ && !include_tparams__) return;
             // validate transformed parameters
             const char* function__ = "validate transformed params";
             (void) function__;  // dummy to suppress unused var warning
-            current_statement_begin__ = 1204;
+            current_statement_begin__ = 1205;
             check_less_or_equal(function__, "r_log_prob", r_log_prob, 0);
             // write transformed parameters
             if (include_tparams__) {
@@ -5151,279 +5162,279 @@ public:
             }
             if (!include_gqs__) return;
             // declare and define generated quantities
-            current_statement_begin__ = 1328;
+            current_statement_begin__ = 1329;
             validate_non_negative_index("log_lik", "((primitive_value(logical_eq(run_type, RUN_TYPE_FIT)) && primitive_value(logical_gt(log_lik_level, -(1)))) ? (logical_gt(log_lik_level, 0) ? get_base1(level_size, log_lik_level, \"level_size\", 1) : num_obs ) : 0 )", ((primitive_value(logical_eq(run_type, RUN_TYPE_FIT)) && primitive_value(logical_gt(log_lik_level, -(1)))) ? (logical_gt(log_lik_level, 0) ? get_base1(level_size, log_lik_level, "level_size", 1) : num_obs ) : 0 ));
             Eigen::Matrix<double, Eigen::Dynamic, 1> log_lik(((primitive_value(logical_eq(run_type, RUN_TYPE_FIT)) && primitive_value(logical_gt(log_lik_level, -(1)))) ? (logical_gt(log_lik_level, 0) ? get_base1(level_size, log_lik_level, "level_size", 1) : num_obs ) : 0 ));
             stan::math::initialize(log_lik, DUMMY_VAR__);
             stan::math::fill(log_lik, DUMMY_VAR__);
-            current_statement_begin__ = 1330;
+            current_statement_begin__ = 1331;
             validate_non_negative_index("total_abducted_log_prob", "(num_abducted_estimands * num_unique_entities)", (num_abducted_estimands * num_unique_entities));
             Eigen::Matrix<double, Eigen::Dynamic, 1> total_abducted_log_prob((num_abducted_estimands * num_unique_entities));
             stan::math::initialize(total_abducted_log_prob, DUMMY_VAR__);
             stan::math::fill(total_abducted_log_prob, DUMMY_VAR__);
-            current_statement_begin__ = 1332;
+            current_statement_begin__ = 1333;
             validate_non_negative_index("iter_atom_log_estimand", "num_atom_estimands", num_atom_estimands);
             validate_non_negative_index("iter_atom_log_estimand", "num_unique_entities", num_unique_entities);
             Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> iter_atom_log_estimand(num_atom_estimands, num_unique_entities);
             stan::math::initialize(iter_atom_log_estimand, DUMMY_VAR__);
             stan::math::fill(iter_atom_log_estimand, DUMMY_VAR__);
-            current_statement_begin__ = 1337;
+            current_statement_begin__ = 1338;
             validate_non_negative_index("iter_diff_estimand", "num_diff_estimands", num_diff_estimands);
             validate_non_negative_index("iter_diff_estimand", "num_unique_entities", num_unique_entities);
             Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> iter_diff_estimand(num_diff_estimands, num_unique_entities);
             stan::math::initialize(iter_diff_estimand, DUMMY_VAR__);
             stan::math::fill(iter_diff_estimand, DUMMY_VAR__);
-            current_statement_begin__ = 1339;
+            current_statement_begin__ = 1340;
             validate_non_negative_index("iter_entity_estimand", "num_all_estimands", num_all_estimands);
             validate_non_negative_index("iter_entity_estimand", "num_unique_entities", num_unique_entities);
             Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> iter_entity_estimand(num_all_estimands, num_unique_entities);
             stan::math::initialize(iter_entity_estimand, DUMMY_VAR__);
             stan::math::fill(iter_entity_estimand, DUMMY_VAR__);
-            current_statement_begin__ = 1340;
+            current_statement_begin__ = 1341;
             validate_non_negative_index("iter_estimand", "num_all_estimands", num_all_estimands);
             Eigen::Matrix<double, Eigen::Dynamic, 1> iter_estimand(num_all_estimands);
             stan::math::initialize(iter_estimand, DUMMY_VAR__);
             stan::math::fill(iter_estimand, DUMMY_VAR__);
-            current_statement_begin__ = 1341;
+            current_statement_begin__ = 1342;
             validate_non_negative_index("iter_level_entity_estimand", "num_all_estimands", num_all_estimands);
             validate_non_negative_index("iter_level_entity_estimand", "sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list()), \"level_size\"))", sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list()), "level_size")));
             Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> iter_level_entity_estimand(num_all_estimands, sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list()), "level_size")));
             stan::math::initialize(iter_level_entity_estimand, DUMMY_VAR__);
             stan::math::fill(iter_level_entity_estimand, DUMMY_VAR__);
-            current_statement_begin__ = 1342;
+            current_statement_begin__ = 1343;
             validate_non_negative_index("iter_level_entity_estimand_sd", "num_all_estimands", num_all_estimands);
             validate_non_negative_index("iter_level_entity_estimand_sd", "(logical_eq(run_type, RUN_TYPE_PRIOR_PREDICT) ? num_estimand_levels : 0 )", (logical_eq(run_type, RUN_TYPE_PRIOR_PREDICT) ? num_estimand_levels : 0 ));
             Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> iter_level_entity_estimand_sd(num_all_estimands, (logical_eq(run_type, RUN_TYPE_PRIOR_PREDICT) ? num_estimand_levels : 0 ));
             stan::math::initialize(iter_level_entity_estimand_sd, DUMMY_VAR__);
             stan::math::fill(iter_level_entity_estimand_sd, DUMMY_VAR__);
-            current_statement_begin__ = 1343;
+            current_statement_begin__ = 1344;
             validate_non_negative_index("iter_between_level_entity_diff_estimand", "num_atom_estimands", num_atom_estimands);
             validate_non_negative_index("iter_between_level_entity_diff_estimand", "(sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), \"level_size\")) - num_between_entity_diff_levels)", (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), "level_size")) - num_between_entity_diff_levels));
             Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> iter_between_level_entity_diff_estimand(num_atom_estimands, (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), "level_size")) - num_between_entity_diff_levels));
             stan::math::initialize(iter_between_level_entity_diff_estimand, DUMMY_VAR__);
             stan::math::fill(iter_between_level_entity_diff_estimand, DUMMY_VAR__);
-            current_statement_begin__ = 1347;
+            current_statement_begin__ = 1348;
             validate_non_negative_index("iter_entity_discretized_histogram_vec", "((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities)", ((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities));
             Eigen::Matrix<double, Eigen::Dynamic, 1> iter_entity_discretized_histogram_vec(((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities));
             stan::math::initialize(iter_entity_discretized_histogram_vec, DUMMY_VAR__);
             stan::math::fill(iter_entity_discretized_histogram_vec, DUMMY_VAR__);
-            current_statement_begin__ = 1348;
+            current_statement_begin__ = 1349;
             validate_non_negative_index("iter_entity_discretized_mean", "num_discretized_groups", num_discretized_groups);
             validate_non_negative_index("iter_entity_discretized_mean", "num_unique_entities", num_unique_entities);
             Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> iter_entity_discretized_mean(num_discretized_groups, num_unique_entities);
             stan::math::initialize(iter_entity_discretized_mean, DUMMY_VAR__);
             stan::math::fill(iter_entity_discretized_mean, DUMMY_VAR__);
-            current_statement_begin__ = 1349;
+            current_statement_begin__ = 1350;
             validate_non_negative_index("iter_entity_discretized_utility", "(logical_gt(num_discrete_utility_values, 0) ? num_discretized_groups : 0 )", (logical_gt(num_discrete_utility_values, 0) ? num_discretized_groups : 0 ));
             validate_non_negative_index("iter_entity_discretized_utility", "num_unique_entities", num_unique_entities);
             Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> iter_entity_discretized_utility((logical_gt(num_discrete_utility_values, 0) ? num_discretized_groups : 0 ), num_unique_entities);
             stan::math::initialize(iter_entity_discretized_utility, DUMMY_VAR__);
             stan::math::fill(iter_entity_discretized_utility, DUMMY_VAR__);
-            current_statement_begin__ = 1350;
+            current_statement_begin__ = 1351;
             validate_non_negative_index("iter_mean_diff_estimand", "num_mean_diff_estimands", num_mean_diff_estimands);
             validate_non_negative_index("iter_mean_diff_estimand", "num_unique_entities", num_unique_entities);
             Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> iter_mean_diff_estimand(num_mean_diff_estimands, num_unique_entities);
             stan::math::initialize(iter_mean_diff_estimand, DUMMY_VAR__);
             stan::math::fill(iter_mean_diff_estimand, DUMMY_VAR__);
-            current_statement_begin__ = 1351;
+            current_statement_begin__ = 1352;
             validate_non_negative_index("iter_utility_diff_estimand", "num_mean_diff_estimands", num_mean_diff_estimands);
             validate_non_negative_index("iter_utility_diff_estimand", "num_unique_entities", num_unique_entities);
             Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> iter_utility_diff_estimand(num_mean_diff_estimands, num_unique_entities);
             stan::math::initialize(iter_utility_diff_estimand, DUMMY_VAR__);
             stan::math::fill(iter_utility_diff_estimand, DUMMY_VAR__);
-            current_statement_begin__ = 1353;
+            current_statement_begin__ = 1354;
             validate_non_negative_index("discrete_marginal_p_r", "(calculate_marginal_prob ? num_discrete_r_types : 0 )", (calculate_marginal_prob ? num_discrete_r_types : 0 ));
             Eigen::Matrix<double, Eigen::Dynamic, 1> discrete_marginal_p_r((calculate_marginal_prob ? num_discrete_r_types : 0 ));
             stan::math::initialize(discrete_marginal_p_r, DUMMY_VAR__);
             stan::math::fill(discrete_marginal_p_r, DUMMY_VAR__);
-            current_statement_begin__ = 1354;
+            current_statement_begin__ = 1355;
             validate_non_negative_index("single_discrete_marginal_p_r", "(calculate_marginal_prob ? total_num_discrete_bg_variable_types : 0 )", (calculate_marginal_prob ? total_num_discrete_bg_variable_types : 0 ));
             Eigen::Matrix<double, Eigen::Dynamic, 1> single_discrete_marginal_p_r((calculate_marginal_prob ? total_num_discrete_bg_variable_types : 0 ));
             stan::math::initialize(single_discrete_marginal_p_r, DUMMY_VAR__);
             stan::math::fill(single_discrete_marginal_p_r, DUMMY_VAR__);
-            current_statement_begin__ = 1355;
+            current_statement_begin__ = 1356;
             validate_non_negative_index("discretized_marginal_p_r", "(calculate_marginal_prob ? total_num_discretized_bg_variable_types : 0 )", (calculate_marginal_prob ? total_num_discretized_bg_variable_types : 0 ));
             Eigen::Matrix<double, Eigen::Dynamic, 1> discretized_marginal_p_r((calculate_marginal_prob ? total_num_discretized_bg_variable_types : 0 ));
             stan::math::initialize(discretized_marginal_p_r, DUMMY_VAR__);
             stan::math::fill(discretized_marginal_p_r, DUMMY_VAR__);
             // generated quantities statements
-            current_statement_begin__ = 1358;
+            current_statement_begin__ = 1359;
             if (as_bool((primitive_value(logical_eq(run_type, RUN_TYPE_FIT)) && primitive_value(logical_gt(log_lik_level, -(1)))))) {
-                current_statement_begin__ = 1359;
+                current_statement_begin__ = 1360;
                 stan::math::assign(log_lik, csr_log_sum_exp(num_obs, (num_r_types * num_unique_entities), obs_candidate_group_ids, obs_candidate_group_csr_row_pos, r_log_prob, pstream__));
             }
-            current_statement_begin__ = 1366;
+            current_statement_begin__ = 1367;
             if (as_bool(logical_gt(num_discrete_estimands, 0))) {
                 {
-                current_statement_begin__ = 1367;
+                current_statement_begin__ = 1368;
                 validate_non_negative_index("full_r_log_prob", "num_experiment_types", num_experiment_types);
                 validate_non_negative_index("full_r_log_prob", "(num_r_types * num_unique_entities)", (num_r_types * num_unique_entities));
                 Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, Eigen::Dynamic> full_r_log_prob(num_experiment_types, (num_r_types * num_unique_entities));
                 stan::math::initialize(full_r_log_prob, DUMMY_VAR__);
                 stan::math::fill(full_r_log_prob, DUMMY_VAR__);
                 stan::math::assign(full_r_log_prob,add(rep_matrix(transpose(r_log_prob), num_experiment_types), rep_matrix(stan::math::log(experiment_types_prob), (num_r_types * num_unique_entities))));
-                current_statement_begin__ = 1369;
+                current_statement_begin__ = 1370;
                 validate_non_negative_index("full_r_log_prob_vec", "(num_r_types_full * num_unique_entities)", (num_r_types_full * num_unique_entities));
                 Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> full_r_log_prob_vec((num_r_types_full * num_unique_entities));
                 stan::math::initialize(full_r_log_prob_vec, DUMMY_VAR__);
                 stan::math::fill(full_r_log_prob_vec, DUMMY_VAR__);
                 stan::math::assign(full_r_log_prob_vec,to_vector(full_r_log_prob));
-                current_statement_begin__ = 1371;
+                current_statement_begin__ = 1372;
                 validate_non_negative_index("iter_atom_log_estimand_vec", "(num_atom_estimands * num_unique_entities)", (num_atom_estimands * num_unique_entities));
                 Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> iter_atom_log_estimand_vec((num_atom_estimands * num_unique_entities));
                 stan::math::initialize(iter_atom_log_estimand_vec, DUMMY_VAR__);
                 stan::math::fill(iter_atom_log_estimand_vec, DUMMY_VAR__);
                 stan::math::assign(iter_atom_log_estimand_vec,csr_log_sum_exp((num_atom_estimands * num_unique_entities), (num_r_types_full * num_unique_entities), entity_est_prob_ids, entity_est_prob_csr_row_pos, full_r_log_prob_vec, pstream__));
-                current_statement_begin__ = 1378;
+                current_statement_begin__ = 1379;
                 validate_non_negative_index("iter_diff_estimand_vec", "(num_diff_estimands * num_unique_entities)", (num_diff_estimands * num_unique_entities));
                 Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> iter_diff_estimand_vec((num_diff_estimands * num_unique_entities));
                 stan::math::initialize(iter_diff_estimand_vec, DUMMY_VAR__);
                 stan::math::fill(iter_diff_estimand_vec, DUMMY_VAR__);
-                current_statement_begin__ = 1380;
+                current_statement_begin__ = 1381;
                 if (as_bool(logical_gt(num_abducted_estimands, 0))) {
-                    current_statement_begin__ = 1381;
+                    current_statement_begin__ = 1382;
                     stan::math::assign(total_abducted_log_prob, csr_log_sum_exp((num_abducted_estimands * num_unique_entities), (num_r_types_full * num_unique_entities), entity_abducted_prob_ids, entity_abducted_prob_csr_row_pos, full_r_log_prob_vec, pstream__));
-                    current_statement_begin__ = 1388;
+                    current_statement_begin__ = 1389;
                     stan::model::assign(iter_atom_log_estimand_vec, 
                                 stan::model::cons_list(stan::model::index_multi(long_entity_abducted_index), stan::model::nil_index_list()), 
                                 subtract(stan::model::rvalue(iter_atom_log_estimand_vec, stan::model::cons_list(stan::model::index_multi(long_entity_abducted_index), stan::model::nil_index_list()), "iter_atom_log_estimand_vec"), total_abducted_log_prob), 
                                 "assigning variable iter_atom_log_estimand_vec");
                 }
-                current_statement_begin__ = 1391;
+                current_statement_begin__ = 1392;
                 stan::math::assign(iter_atom_log_estimand, to_matrix(iter_atom_log_estimand_vec, num_atom_estimands, num_unique_entities));
-                current_statement_begin__ = 1393;
+                current_statement_begin__ = 1394;
                 if (as_bool(logical_gt(num_diff_estimands, 0))) {
-                    current_statement_begin__ = 1394;
+                    current_statement_begin__ = 1395;
                     stan::math::assign(iter_diff_estimand_vec, csr_diff_exp((num_diff_estimands * num_unique_entities), (num_atom_estimands * num_unique_entities), entity_diff_estimand_ids, iter_atom_log_estimand_vec, pstream__));
-                    current_statement_begin__ = 1400;
+                    current_statement_begin__ = 1401;
                     stan::math::assign(iter_diff_estimand, to_matrix(iter_diff_estimand_vec, num_diff_estimands, num_unique_entities));
                 }
-                current_statement_begin__ = 1403;
+                current_statement_begin__ = 1404;
                 if (as_bool(logical_gt(num_discretized_groups, 0))) {
                     {
-                    current_statement_begin__ = 1404;
+                    current_statement_begin__ = 1405;
                     validate_non_negative_index("iter_entity_discretized_mean_vec", "(num_discretized_groups * num_unique_entities)", (num_discretized_groups * num_unique_entities));
                     Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> iter_entity_discretized_mean_vec((num_discretized_groups * num_unique_entities));
                     stan::math::initialize(iter_entity_discretized_mean_vec, DUMMY_VAR__);
                     stan::math::fill(iter_entity_discretized_mean_vec, DUMMY_VAR__);
-                    current_statement_begin__ = 1406;
+                    current_statement_begin__ = 1407;
                     stan::math::assign(iter_entity_discretized_histogram_vec, csr_matrix_times_vector(((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities), ((num_atom_estimands * num_unique_entities) + 1), entity_histogram_vec, entity_histogram_ids, entity_histogram_csr_row_pos, append_row(stan::math::exp(iter_atom_log_estimand_vec), 1)));
-                    current_statement_begin__ = 1416;
+                    current_statement_begin__ = 1417;
                     stan::math::assign(iter_entity_discretized_mean_vec, csr_matrix_times_vector((num_discretized_groups * num_unique_entities), ((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities), (use_random_binpoint ? stan::math::promote_scalar<double>(to_vector(uniform_rng(entity_discretize_bin_alpha, entity_discretize_bin_beta, base_rng__))) : stan::math::promote_scalar<double>(entity_midpoint_vec) ), entity_midpoint_ids, entity_midpoint_csr_row_pos, iter_entity_discretized_histogram_vec));
-                    current_statement_begin__ = 1425;
+                    current_statement_begin__ = 1426;
                     if (as_bool(logical_gt(num_discrete_utility_values, 0))) {
                         {
-                        current_statement_begin__ = 1426;
+                        current_statement_begin__ = 1427;
                         validate_non_negative_index("iter_entity_discretized_utility_vec", "(num_discretized_groups * num_unique_entities)", (num_discretized_groups * num_unique_entities));
                         Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> iter_entity_discretized_utility_vec((num_discretized_groups * num_unique_entities));
                         stan::math::initialize(iter_entity_discretized_utility_vec, DUMMY_VAR__);
                         stan::math::fill(iter_entity_discretized_utility_vec, DUMMY_VAR__);
                         stan::math::assign(iter_entity_discretized_utility_vec,csr_matrix_times_vector((num_discretized_groups * num_unique_entities), ((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities), entity_utility_vec, entity_midpoint_ids, entity_midpoint_csr_row_pos, iter_entity_discretized_histogram_vec));
-                        current_statement_begin__ = 1436;
+                        current_statement_begin__ = 1437;
                         stan::math::assign(iter_entity_discretized_utility, to_matrix(iter_entity_discretized_utility_vec, num_discretized_groups, num_unique_entities));
-                        current_statement_begin__ = 1438;
+                        current_statement_begin__ = 1439;
                         if (as_bool(logical_gt(num_utility_diff_estimands, 0))) {
                             {
-                            current_statement_begin__ = 1439;
+                            current_statement_begin__ = 1440;
                             validate_non_negative_index("iter_utility_diff_estimand_vec", "(num_utility_diff_estimands * num_unique_entities)", (num_utility_diff_estimands * num_unique_entities));
                             Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> iter_utility_diff_estimand_vec((num_utility_diff_estimands * num_unique_entities));
                             stan::math::initialize(iter_utility_diff_estimand_vec, DUMMY_VAR__);
                             stan::math::fill(iter_utility_diff_estimand_vec, DUMMY_VAR__);
                             stan::math::assign(iter_utility_diff_estimand_vec,csr_matrix_times_vector((num_utility_diff_estimands * num_unique_entities), (num_discretized_groups * num_unique_entities), vec_utility_diff, entity_utility_diff_estimand_ids, entity_utility_diff_estimand_csr_row_pos, iter_entity_discretized_utility_vec));
-                            current_statement_begin__ = 1447;
+                            current_statement_begin__ = 1448;
                             stan::math::assign(iter_utility_diff_estimand, to_matrix(iter_utility_diff_estimand_vec, num_utility_diff_estimands, num_unique_entities));
                             }
                         }
                         }
                     }
-                    current_statement_begin__ = 1451;
+                    current_statement_begin__ = 1452;
                     stan::math::assign(iter_entity_discretized_mean, to_matrix(iter_entity_discretized_mean_vec, num_discretized_groups, num_unique_entities));
-                    current_statement_begin__ = 1453;
+                    current_statement_begin__ = 1454;
                     if (as_bool(logical_gt(num_mean_diff_estimands, 0))) {
                         {
-                        current_statement_begin__ = 1454;
+                        current_statement_begin__ = 1455;
                         validate_non_negative_index("iter_mean_diff_estimand_vec", "(num_mean_diff_estimands * num_unique_entities)", (num_mean_diff_estimands * num_unique_entities));
                         Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> iter_mean_diff_estimand_vec((num_mean_diff_estimands * num_unique_entities));
                         stan::math::initialize(iter_mean_diff_estimand_vec, DUMMY_VAR__);
                         stan::math::fill(iter_mean_diff_estimand_vec, DUMMY_VAR__);
                         stan::math::assign(iter_mean_diff_estimand_vec,csr_matrix_times_vector((num_mean_diff_estimands * num_unique_entities), (num_discretized_groups * num_unique_entities), vec_mean_diff, entity_mean_diff_estimand_ids, entity_mean_diff_estimand_csr_row_pos, iter_entity_discretized_mean_vec));
-                        current_statement_begin__ = 1462;
+                        current_statement_begin__ = 1463;
                         stan::math::assign(iter_mean_diff_estimand, to_matrix(iter_mean_diff_estimand_vec, num_mean_diff_estimands, num_unique_entities));
                         }
                     }
                     }
                 }
-                current_statement_begin__ = 1467;
+                current_statement_begin__ = 1468;
                 stan::math::assign(iter_entity_estimand, append_row(append_row(iter_atom_log_estimand, append_row(iter_diff_estimand, append_row(iter_entity_discretized_mean, iter_entity_discretized_utility))), append_row(iter_mean_diff_estimand, iter_utility_diff_estimand)));
-                current_statement_begin__ = 1481;
+                current_statement_begin__ = 1482;
                 stan::model::assign(iter_estimand, 
                             stan::model::cons_list(stan::model::index_min_max(1, num_atom_estimands), stan::model::nil_index_list()), 
                             stan::math::exp(csr_weighted_log_mean(stan::model::rvalue(iter_entity_estimand, stan::model::cons_list(stan::model::index_min_max(1, num_atom_estimands), stan::model::nil_index_list()), "iter_entity_estimand"), stan::math::log(unique_entity_prop), pstream__)), 
                             "assigning variable iter_estimand");
-                current_statement_begin__ = 1482;
+                current_statement_begin__ = 1483;
                 stan::model::assign(iter_estimand, 
                             stan::model::cons_list(stan::model::index_min((num_atom_estimands + 1)), stan::model::nil_index_list()), 
                             multiply(stan::model::rvalue(iter_entity_estimand, stan::model::cons_list(stan::model::index_min((num_atom_estimands + 1)), stan::model::nil_index_list()), "iter_entity_estimand"), unique_entity_prop), 
                             "assigning variable iter_estimand");
-                current_statement_begin__ = 1484;
+                current_statement_begin__ = 1485;
                 if (as_bool(logical_gt(num_estimand_levels, 0))) {
                     {
-                    current_statement_begin__ = 1485;
+                    current_statement_begin__ = 1486;
                     validate_non_negative_index("iter_level_entity_estimand_vec", "(num_all_estimands * sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list()), \"level_size\")))", (num_all_estimands * sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list()), "level_size"))));
                     Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> iter_level_entity_estimand_vec((num_all_estimands * sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list()), "level_size"))));
                     stan::math::initialize(iter_level_entity_estimand_vec, DUMMY_VAR__);
                     stan::math::fill(iter_level_entity_estimand_vec, DUMMY_VAR__);
                     stan::math::assign(iter_level_entity_estimand_vec,csr_matrix_times_vector((num_all_estimands * sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list()), "level_size"))), (num_all_estimands * num_unique_entities), level_estimands_csr_vec, entity_estimand_ids, entity_estimand_csr_row_pos, to_vector(iter_entity_estimand)));
-                    current_statement_begin__ = 1495;
+                    current_statement_begin__ = 1496;
                     stan::math::assign(iter_level_entity_estimand, to_matrix(iter_level_entity_estimand_vec, num_all_estimands, sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list()), "level_size"))));
-                    current_statement_begin__ = 1497;
+                    current_statement_begin__ = 1498;
                     if (as_bool(logical_eq(run_type, RUN_TYPE_PRIOR_PREDICT))) {
                         {
-                        current_statement_begin__ = 1498;
+                        current_statement_begin__ = 1499;
                         int level_entity_pos(0);
                         (void) level_entity_pos;  // dummy to suppress unused var warning
                         stan::math::fill(level_entity_pos, std::numeric_limits<int>::min());
                         stan::math::assign(level_entity_pos,1);
-                        current_statement_begin__ = 1500;
+                        current_statement_begin__ = 1501;
                         for (int est_level_index_index = 1; est_level_index_index <= num_estimand_levels; ++est_level_index_index) {
                             {
-                            current_statement_begin__ = 1501;
+                            current_statement_begin__ = 1502;
                             int est_level_index(0);
                             (void) est_level_index;  // dummy to suppress unused var warning
                             stan::math::fill(est_level_index, std::numeric_limits<int>::min());
                             stan::math::assign(est_level_index,get_base1(estimand_levels, est_level_index_index, "estimand_levels", 1));
-                            current_statement_begin__ = 1502;
+                            current_statement_begin__ = 1503;
                             int level_entity_end(0);
                             (void) level_entity_end;  // dummy to suppress unused var warning
                             stan::math::fill(level_entity_end, std::numeric_limits<int>::min());
                             stan::math::assign(level_entity_end,((level_entity_pos + get_base1(level_size, est_level_index, "level_size", 1)) - 1));
-                            current_statement_begin__ = 1504;
+                            current_statement_begin__ = 1505;
                             validate_non_negative_index("level_entity_means", "num_all_estimands", num_all_estimands);
                             Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> level_entity_means(num_all_estimands);
                             stan::math::initialize(level_entity_means, DUMMY_VAR__);
                             stan::math::fill(level_entity_means, DUMMY_VAR__);
                             stan::math::assign(level_entity_means,multiply(stan::model::rvalue(iter_level_entity_estimand, stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_min_max(level_entity_pos, level_entity_end), stan::model::nil_index_list())), "iter_level_entity_estimand"), rep_vector((1.0 / get_base1(level_size, est_level_index, "level_size", 1)), get_base1(level_size, est_level_index, "level_size", 1))));
-                            current_statement_begin__ = 1506;
+                            current_statement_begin__ = 1507;
                             stan::model::assign(iter_level_entity_estimand_sd, 
                                         stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(est_level_index), stan::model::nil_index_list())), 
                                         stan::math::sqrt(multiply(square(subtract(stan::model::rvalue(iter_level_entity_estimand, stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_min_max(level_entity_pos, level_entity_end), stan::model::nil_index_list())), "iter_level_entity_estimand"), rep_matrix(level_entity_means, get_base1(level_size, est_level_index, "level_size", 1)))), rep_vector((1.0 / (get_base1(level_size, est_level_index, "level_size", 1) - 1)), get_base1(level_size, est_level_index, "level_size", 1)))), 
                                         "assigning variable iter_level_entity_estimand_sd");
-                            current_statement_begin__ = 1512;
+                            current_statement_begin__ = 1513;
                             stan::math::assign(level_entity_pos, (level_entity_end + 1));
                             }
                         }
                         }
                     }
-                    current_statement_begin__ = 1516;
+                    current_statement_begin__ = 1517;
                     if (as_bool(logical_gt(num_between_entity_diff_levels, 0))) {
                         {
-                        current_statement_begin__ = 1517;
+                        current_statement_begin__ = 1518;
                         validate_non_negative_index("iter_between_level_entity_diff_estimand_vec", "(num_atom_estimands * (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), \"level_size\")) - num_between_entity_diff_levels))", (num_atom_estimands * (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), "level_size")) - num_between_entity_diff_levels)));
                         Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> iter_between_level_entity_diff_estimand_vec((num_atom_estimands * (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), "level_size")) - num_between_entity_diff_levels)));
                         stan::math::initialize(iter_between_level_entity_diff_estimand_vec, DUMMY_VAR__);
                         stan::math::fill(iter_between_level_entity_diff_estimand_vec, DUMMY_VAR__);
                         stan::math::assign(iter_between_level_entity_diff_estimand_vec,csr_matrix_times_vector((num_atom_estimands * (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), "level_size")) - num_between_entity_diff_levels)), (num_all_estimands * sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list()), "level_size"))), between_entity_diff_csr_vec, between_entity_diff_csr_ids, between_entity_diff_csr_row_pos, iter_level_entity_estimand_vec));
-                        current_statement_begin__ = 1527;
+                        current_statement_begin__ = 1528;
                         stan::math::assign(iter_between_level_entity_diff_estimand, to_matrix(iter_between_level_entity_diff_estimand_vec, num_atom_estimands, (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), "level_size")) - num_between_entity_diff_levels)));
                         }
                     }
@@ -5431,55 +5442,55 @@ public:
                 }
                 }
             }
-            current_statement_begin__ = 1532;
+            current_statement_begin__ = 1533;
             if (as_bool(calculate_marginal_prob)) {
                 {
-                current_statement_begin__ = 1533;
+                current_statement_begin__ = 1534;
                 validate_non_negative_index("discrete_marginal_log_p_r", "num_discrete_r_types", num_discrete_r_types);
                 Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> discrete_marginal_log_p_r(num_discrete_r_types);
                 stan::math::initialize(discrete_marginal_log_p_r, DUMMY_VAR__);
                 stan::math::fill(discrete_marginal_log_p_r, DUMMY_VAR__);
                 stan::math::assign(discrete_marginal_log_p_r,csr_log_sum_exp2(num_discrete_r_types, (num_r_types * num_unique_entities), stan::math::log(discrete_marginal_prob_csr_vec), entity_discrete_marginal_prob_ids, entity_discrete_marginal_prob_csr_row_pos, r_log_prob, pstream__));
-                current_statement_begin__ = 1541;
+                current_statement_begin__ = 1542;
                 validate_non_negative_index("single_discrete_marginal_log_p_r", "total_num_discrete_bg_variable_types", total_num_discrete_bg_variable_types);
                 Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> single_discrete_marginal_log_p_r(total_num_discrete_bg_variable_types);
                 stan::math::initialize(single_discrete_marginal_log_p_r, DUMMY_VAR__);
                 stan::math::fill(single_discrete_marginal_log_p_r, DUMMY_VAR__);
                 stan::math::assign(single_discrete_marginal_log_p_r,csr_log_sum_exp2(total_num_discrete_bg_variable_types, (num_r_types * num_unique_entities), stan::math::log(single_discrete_marginal_prob_csr_vec), entity_single_discrete_marginal_prob_ids, entity_single_discrete_marginal_prob_csr_row_pos, r_log_prob, pstream__));
-                current_statement_begin__ = 1549;
-                stan::math::assign(single_discrete_marginal_p_r, stan::math::exp(single_discrete_marginal_log_p_r));
                 current_statement_begin__ = 1550;
+                stan::math::assign(single_discrete_marginal_p_r, stan::math::exp(single_discrete_marginal_log_p_r));
+                current_statement_begin__ = 1551;
                 stan::math::assign(discrete_marginal_p_r, stan::math::exp(discrete_marginal_log_p_r));
-                current_statement_begin__ = 1552;
+                current_statement_begin__ = 1553;
                 if (as_bool(logical_gt(total_num_discretized_bg_variable_types, 0))) {
                     {
-                    current_statement_begin__ = 1553;
+                    current_statement_begin__ = 1554;
                     validate_non_negative_index("discretized_marginal_log_p_r", "total_num_discretized_bg_variable_types", total_num_discretized_bg_variable_types);
                     Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> discretized_marginal_log_p_r(total_num_discretized_bg_variable_types);
                     stan::math::initialize(discretized_marginal_log_p_r, DUMMY_VAR__);
                     stan::math::fill(discretized_marginal_log_p_r, DUMMY_VAR__);
                     stan::math::assign(discretized_marginal_log_p_r,csr_log_sum_exp2(total_num_discretized_bg_variable_types, (num_r_types * num_unique_entities), stan::math::log(discretized_marginal_prob_csr_vec), entity_discretized_marginal_prob_ids, entity_discretized_marginal_prob_csr_row_pos, r_log_prob, pstream__));
-                    current_statement_begin__ = 1561;
-                    stan::math::assign(discretized_marginal_log_p_r, subtract(discretized_marginal_log_p_r, to_vector(rep_matrix(discrete_marginal_log_p_r, (num_discretized_bg_variables * num_discretized_r_types)))));
                     current_statement_begin__ = 1562;
+                    stan::math::assign(discretized_marginal_log_p_r, subtract(discretized_marginal_log_p_r, to_vector(rep_matrix(discrete_marginal_log_p_r, (num_discretized_bg_variables * num_discretized_r_types)))));
+                    current_statement_begin__ = 1563;
                     stan::math::assign(discretized_marginal_p_r, stan::math::exp(discretized_marginal_log_p_r));
                     }
                 }
                 }
             }
             // validate, write generated quantities
-            current_statement_begin__ = 1328;
+            current_statement_begin__ = 1329;
             size_t log_lik_j_1_max__ = ((primitive_value(logical_eq(run_type, RUN_TYPE_FIT)) && primitive_value(logical_gt(log_lik_level, -(1)))) ? (logical_gt(log_lik_level, 0) ? get_base1(level_size, log_lik_level, "level_size", 1) : num_obs ) : 0 );
             for (size_t j_1__ = 0; j_1__ < log_lik_j_1_max__; ++j_1__) {
                 vars__.push_back(log_lik(j_1__));
             }
-            current_statement_begin__ = 1330;
+            current_statement_begin__ = 1331;
             check_less_or_equal(function__, "total_abducted_log_prob", total_abducted_log_prob, 0);
             size_t total_abducted_log_prob_j_1_max__ = (num_abducted_estimands * num_unique_entities);
             for (size_t j_1__ = 0; j_1__ < total_abducted_log_prob_j_1_max__; ++j_1__) {
                 vars__.push_back(total_abducted_log_prob(j_1__));
             }
-            current_statement_begin__ = 1332;
+            current_statement_begin__ = 1333;
             size_t iter_atom_log_estimand_j_2_max__ = num_unique_entities;
             size_t iter_atom_log_estimand_j_1_max__ = num_atom_estimands;
             for (size_t j_2__ = 0; j_2__ < iter_atom_log_estimand_j_2_max__; ++j_2__) {
@@ -5487,7 +5498,7 @@ public:
                     vars__.push_back(iter_atom_log_estimand(j_1__, j_2__));
                 }
             }
-            current_statement_begin__ = 1337;
+            current_statement_begin__ = 1338;
             size_t iter_diff_estimand_j_2_max__ = num_unique_entities;
             size_t iter_diff_estimand_j_1_max__ = num_diff_estimands;
             for (size_t j_2__ = 0; j_2__ < iter_diff_estimand_j_2_max__; ++j_2__) {
@@ -5495,7 +5506,7 @@ public:
                     vars__.push_back(iter_diff_estimand(j_1__, j_2__));
                 }
             }
-            current_statement_begin__ = 1339;
+            current_statement_begin__ = 1340;
             size_t iter_entity_estimand_j_2_max__ = num_unique_entities;
             size_t iter_entity_estimand_j_1_max__ = num_all_estimands;
             for (size_t j_2__ = 0; j_2__ < iter_entity_estimand_j_2_max__; ++j_2__) {
@@ -5503,12 +5514,12 @@ public:
                     vars__.push_back(iter_entity_estimand(j_1__, j_2__));
                 }
             }
-            current_statement_begin__ = 1340;
+            current_statement_begin__ = 1341;
             size_t iter_estimand_j_1_max__ = num_all_estimands;
             for (size_t j_1__ = 0; j_1__ < iter_estimand_j_1_max__; ++j_1__) {
                 vars__.push_back(iter_estimand(j_1__));
             }
-            current_statement_begin__ = 1341;
+            current_statement_begin__ = 1342;
             size_t iter_level_entity_estimand_j_2_max__ = sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(estimand_levels), stan::model::nil_index_list()), "level_size"));
             size_t iter_level_entity_estimand_j_1_max__ = num_all_estimands;
             for (size_t j_2__ = 0; j_2__ < iter_level_entity_estimand_j_2_max__; ++j_2__) {
@@ -5516,7 +5527,7 @@ public:
                     vars__.push_back(iter_level_entity_estimand(j_1__, j_2__));
                 }
             }
-            current_statement_begin__ = 1342;
+            current_statement_begin__ = 1343;
             size_t iter_level_entity_estimand_sd_j_2_max__ = (logical_eq(run_type, RUN_TYPE_PRIOR_PREDICT) ? num_estimand_levels : 0 );
             size_t iter_level_entity_estimand_sd_j_1_max__ = num_all_estimands;
             for (size_t j_2__ = 0; j_2__ < iter_level_entity_estimand_sd_j_2_max__; ++j_2__) {
@@ -5524,7 +5535,7 @@ public:
                     vars__.push_back(iter_level_entity_estimand_sd(j_1__, j_2__));
                 }
             }
-            current_statement_begin__ = 1343;
+            current_statement_begin__ = 1344;
             size_t iter_between_level_entity_diff_estimand_j_2_max__ = (sum(stan::model::rvalue(level_size, stan::model::cons_list(stan::model::index_multi(between_entity_diff_levels), stan::model::nil_index_list()), "level_size")) - num_between_entity_diff_levels);
             size_t iter_between_level_entity_diff_estimand_j_1_max__ = num_atom_estimands;
             for (size_t j_2__ = 0; j_2__ < iter_between_level_entity_diff_estimand_j_2_max__; ++j_2__) {
@@ -5532,12 +5543,12 @@ public:
                     vars__.push_back(iter_between_level_entity_diff_estimand(j_1__, j_2__));
                 }
             }
-            current_statement_begin__ = 1347;
+            current_statement_begin__ = 1348;
             size_t iter_entity_discretized_histogram_vec_j_1_max__ = ((num_discretized_groups * (num_cutpoints - 1)) * num_unique_entities);
             for (size_t j_1__ = 0; j_1__ < iter_entity_discretized_histogram_vec_j_1_max__; ++j_1__) {
                 vars__.push_back(iter_entity_discretized_histogram_vec(j_1__));
             }
-            current_statement_begin__ = 1348;
+            current_statement_begin__ = 1349;
             size_t iter_entity_discretized_mean_j_2_max__ = num_unique_entities;
             size_t iter_entity_discretized_mean_j_1_max__ = num_discretized_groups;
             for (size_t j_2__ = 0; j_2__ < iter_entity_discretized_mean_j_2_max__; ++j_2__) {
@@ -5545,7 +5556,7 @@ public:
                     vars__.push_back(iter_entity_discretized_mean(j_1__, j_2__));
                 }
             }
-            current_statement_begin__ = 1349;
+            current_statement_begin__ = 1350;
             check_greater_or_equal(function__, "iter_entity_discretized_utility", iter_entity_discretized_utility, min(utility));
             check_less_or_equal(function__, "iter_entity_discretized_utility", iter_entity_discretized_utility, max(utility));
             size_t iter_entity_discretized_utility_j_2_max__ = num_unique_entities;
@@ -5555,7 +5566,7 @@ public:
                     vars__.push_back(iter_entity_discretized_utility(j_1__, j_2__));
                 }
             }
-            current_statement_begin__ = 1350;
+            current_statement_begin__ = 1351;
             size_t iter_mean_diff_estimand_j_2_max__ = num_unique_entities;
             size_t iter_mean_diff_estimand_j_1_max__ = num_mean_diff_estimands;
             for (size_t j_2__ = 0; j_2__ < iter_mean_diff_estimand_j_2_max__; ++j_2__) {
@@ -5563,7 +5574,7 @@ public:
                     vars__.push_back(iter_mean_diff_estimand(j_1__, j_2__));
                 }
             }
-            current_statement_begin__ = 1351;
+            current_statement_begin__ = 1352;
             size_t iter_utility_diff_estimand_j_2_max__ = num_unique_entities;
             size_t iter_utility_diff_estimand_j_1_max__ = num_mean_diff_estimands;
             for (size_t j_2__ = 0; j_2__ < iter_utility_diff_estimand_j_2_max__; ++j_2__) {
@@ -5571,17 +5582,17 @@ public:
                     vars__.push_back(iter_utility_diff_estimand(j_1__, j_2__));
                 }
             }
-            current_statement_begin__ = 1353;
+            current_statement_begin__ = 1354;
             size_t discrete_marginal_p_r_j_1_max__ = (calculate_marginal_prob ? num_discrete_r_types : 0 );
             for (size_t j_1__ = 0; j_1__ < discrete_marginal_p_r_j_1_max__; ++j_1__) {
                 vars__.push_back(discrete_marginal_p_r(j_1__));
             }
-            current_statement_begin__ = 1354;
+            current_statement_begin__ = 1355;
             size_t single_discrete_marginal_p_r_j_1_max__ = (calculate_marginal_prob ? total_num_discrete_bg_variable_types : 0 );
             for (size_t j_1__ = 0; j_1__ < single_discrete_marginal_p_r_j_1_max__; ++j_1__) {
                 vars__.push_back(single_discrete_marginal_p_r(j_1__));
             }
-            current_statement_begin__ = 1355;
+            current_statement_begin__ = 1356;
             size_t discretized_marginal_p_r_j_1_max__ = (calculate_marginal_prob ? total_num_discretized_bg_variable_types : 0 );
             for (size_t j_1__ = 0; j_1__ < discretized_marginal_p_r_j_1_max__; ++j_1__) {
                 vars__.push_back(discretized_marginal_p_r(j_1__));


### PR DESCRIPTION
Trying to improve how priors are specified for discrete variable latent types. Still not satisfactory. Ideally, I would like to be able to specify priors on the marginal probabilities of types, not over the joint probability.